### PR TITLE
Updates accounting for Pyomo logical expression system, Boolean indicator_vars, and importing models

### DIFF
--- a/gdplib/biofuel/model.py
+++ b/gdplib/biofuel/model.py
@@ -190,7 +190,7 @@ def build_model():
     @m.Expression(doc="million $")
     def raw_material_fixed_transport_cost(m):
         return (
-            sum(m.supply_route_active[sup, site].indicator_var
+            sum(m.supply_route_active[sup, site].binary_indicator_var
                 for sup in m.suppliers for site in m.potential_sites)
             * m.transport_fixed_cost / 1000)
 
@@ -205,7 +205,7 @@ def build_model():
     @m.Expression(doc="million $")
     def product_fixed_transport_cost(m):
         return (
-            sum(m.product_route_active[site, mkt].indicator_var
+            sum(m.product_route_active[site, mkt].binary_indicator_var
                 for site in m.potential_sites for mkt in m.markets)
             * m.transport_fixed_cost / 1000)
 
@@ -398,7 +398,7 @@ if __name__ == "__main__":
                      (m.market_x[mkt] + 2, m.market_y[mkt] + 2),
                      fontsize='x-small')
     for site in m.potential_sites:
-        if m.site_inactive[site].indicator_var.value == 0:
+        if m.site_inactive[site].binary_indicator_var.value == 0:
             plt.annotate(
                 'p%s' % site, (m.site_x[site], m.site_y[site]),
                 (m.site_x[site] + 2, m.site_y[site] + 2),
@@ -414,13 +414,13 @@ if __name__ == "__main__":
             (m.supplier_x[sup] + 2, m.supplier_y[sup] + 2),
             fontsize='x-small')
     for sup, site in m.suppliers * m.potential_sites:
-        if fabs(m.supply_route_active[sup, site].indicator_var.value - 1) <= 1E-3:
+        if fabs(m.supply_route_active[sup, site].binary_indicator_var.value - 1) <= 1E-3:
             plt.arrow(m.supplier_x[sup], m.supplier_y[sup],
                       m.site_x[site] - m.supplier_x[sup],
                       m.site_y[site] - m.supplier_y[sup],
                       width=0.8, length_includes_head=True, color='b')
     for site, mkt in m.potential_sites * m.markets:
-        if fabs(m.product_route_active[site, mkt].indicator_var.value - 1) <= 1E-3:
+        if fabs(m.product_route_active[site, mkt].binary_indicator_var.value - 1) <= 1E-3:
             plt.arrow(m.site_x[site], m.site_y[site],
                       m.market_x[mkt] - m.site_x[site],
                       m.market_y[mkt] - m.site_y[site],

--- a/gdplib/gdp_col/column.py
+++ b/gdplib/gdp_col/column.py
@@ -39,7 +39,7 @@ def build_column(min_trays, max_trays, xD, xB):
     def tray_no_tray(b, t):
         return [b.tray[t], b.no_tray[t]]
     m.minimum_num_trays = Constraint(
-        expr=sum(m.tray[t].indicator_var
+        expr=sum(m.tray[t].binary_indicator_var
                  for t in m.conditional_trays) + 1  # for feed tray
         >= min_trays)
 
@@ -201,10 +201,9 @@ def build_column(min_trays, max_trays, xD, xB):
         return m.B['toluene'] >= m.bottoms_purity * m.bot
 
     # m.obj = Objective(expr=(m.Qc + m.Qb) * 1E-3, sense=minimize)
-    m.obj = Objective(
-        expr=(m.Qc + m.Qb) * 1E3 + 1E3 * (
-            sum(m.tray[t].indicator_var for t in m.conditional_trays) + 1),
-        sense=minimize)
+    m.obj = Objective( expr=(m.Qc + m.Qb) * 1E3 + 1E3 * (
+        sum(m.tray[t].binary_indicator_var for t in m.conditional_trays) + 1),
+                       sense=minimize)
     # m.obj = Objective(
     #     expr=sum(m.tray[t].indicator_var for t in m.conditional_trays) + 1)
 
@@ -220,9 +219,11 @@ def build_column(min_trays, max_trays, xD, xB):
     def tray_ordering(m, t):
         """Trays close to the feed should be activated first."""
         if t + 1 < m.condens_tray and t > m.feed_tray:
-            return m.tray[t].indicator_var >= m.tray[t + 1].indicator_var
+            return m.tray[t].binary_indicator_var >= \
+                m.tray[t + 1].binary_indicator_var
         elif t > m.reboil_tray and t + 1 < m.feed_tray:
-            return m.tray[t + 1].indicator_var >= m.tray[t].indicator_var
+            return m.tray[t + 1].binary_indicator_var >= \
+                m.tray[t].binary_indicator_var
         else:
             return Constraint.NoConstraint
 

--- a/gdplib/gdp_col/initialize.py
+++ b/gdplib/gdp_col/initialize.py
@@ -4,15 +4,23 @@ from __future__ import division
 import pandas
 from math import fabs, floor
 from pyomo.environ import value, exp
+import os
+
+gdp_col_dir = os.path.dirname(os.path.realpath(__file__))
 
 
-def initialize(m):
+def initialize(m, excel_file=None):
     m.reflux_frac.set_value(value(
         m.reflux_ratio / (1 + m.reflux_ratio)))
     m.boilup_frac.set_value(value(
         m.reboil_ratio / (1 + m.reboil_ratio)))
+    
+    if excel_file is None:
+        excel_file = 'init.xlsx'
 
-    _excel_sheets = pandas.read_excel('init.xlsx', sheet_name=None)
+    print(gdp_col_dir)
+    _excel_sheets = pandas.read_excel("%s/init.xlsx" % gdp_col_dir,
+                                      sheet_name=None)
 
     def set_value_if_not_fixed(var, val):
         """Set variable to the value if it is not fixed."""
@@ -22,7 +30,7 @@ def initialize(m):
     active_trays = [
         t for t in m.trays
         if t not in m.conditional_trays or
-        fabs(value(m.tray[t].indicator_var - 1)) <= 1E-3]
+        fabs(value(m.tray[t].binary_indicator_var - 1)) <= 1E-3]
     num_active_trays = len(active_trays)
 
     feed_tray = m.feed_tray

--- a/gdplib/gdp_col/main.py
+++ b/gdplib/gdp_col/main.py
@@ -35,7 +35,7 @@ def main():
     m.BigM[None] = 100
 
     SolverFactory('gdpopt').solve(
-        m, tee=True, init_strategy='fix_disjuncts',
+        m, tee=True, strategy='LOA', init_strategy='fix_disjuncts',
         mip_solver='glpk')
     log_infeasible_constraints(m, tol=1E-3)
     display_column(m)

--- a/gdplib/hda/HDA_GDP_gdpopt.py
+++ b/gdplib/hda/HDA_GDP_gdpopt.py
@@ -1799,13 +1799,13 @@ def HDA_model():
     m.diphenyl_product = Param(initialize = 11.84,doc= "diphenyl product profit(diphenyl = 100%)")
 
     def profits_from_paper(m):
-        return 510. * (- m.h2_feed_cost * m.f[1] - m.toluene_feed_cost * (m.f[66] + m.f[67]) + m.benzene_product * m.f[31] + m.diphenyl_product * m.f[35] + m.hydrogen_purge_value * (m.fc[4, 'h2'] + m.fc[28, 'h2'] + m.fc[53, 'h2'] + m.fc[55, 'h2']) + m.meathane_purge_value * (m.fc[4, 'ch4'] + m.fc[28, 'ch4'] + m.fc[53, 'ch4'] + m.fc[55, 'ch4'])) - m.compressor_linear_coeffcient * (m.elec[1] + m.elec[2] + m.elec[3]) - m.compressor_linear_coeffcient  * m.elec[4] - m.compressor_fixed_cost * (m.purify_H2.indicator_var + m.recycle_hydrogen.indicator_var + m.absorber_hydrogen.indicator_var) - m.compressor_fixed_cost * m.recycle_methane_membrane.indicator_var - sum((m.electricity_cost * m.elec[comp]) for comp in m.comp) - (m.adiabtic_reactor_fixed_cost * m.adiabatic_reactor.indicator_var + m.adiabtic_reactor_linear_coeffcient * m.rctvol[1]) -  (m.isothermal_reactor_fixed_cost * m.isothermal_reactor.indicator_var + m.isothermal_reactor_linear_coeffcient * m.rctvol[2]) - m.cooling_cost/1000 * m.q[2] - (m.stabilizing_column_fixed_cost * m.methane_distillation_column.indicator_var +m.stabilizing_column_linear_coeffcient * m.ndist[1]) - (m.benzene_column_fixed_cost+ m.benzene_column_linear_coeffcient  * m.ndist[2]) - (m.toluene_column_fixed_cost * m.toluene_distillation_column.indicator_var + m.toluene_column_linear_coeffcient * m.ndist[3]) - (m.membrane_seperator_fixed_cost * m.purify_H2.indicator_var + m.membrane_seperator_linear_coeffcient * m.f[3]) - (m.membrane_seperator_fixed_cost * m.recycle_methane_membrane.indicator_var + m.membrane_seperator_linear_coeffcient * m.f[54]) - (m.abs_fixed_cost * m.absorber_hydrogen.indicator_var + m.abs_linear_coeffcient * m.nabs[1]) - ( m.fuel_cost * m.qfuel[1] + m.furnace_linear_coeffcient* m.qfuel[1] ) - sum(m.cooling_cost * m.qc[hec] for hec in m.hec) - sum(m.heating_cost * m.qh[heh] for heh in m.heh) - m.furnace_fixed_cost  
+        return 510. * (- m.h2_feed_cost * m.f[1] - m.toluene_feed_cost * (m.f[66] + m.f[67]) + m.benzene_product * m.f[31] + m.diphenyl_product * m.f[35] + m.hydrogen_purge_value * (m.fc[4, 'h2'] + m.fc[28, 'h2'] + m.fc[53, 'h2'] + m.fc[55, 'h2']) + m.meathane_purge_value * (m.fc[4, 'ch4'] + m.fc[28, 'ch4'] + m.fc[53, 'ch4'] + m.fc[55, 'ch4'])) - m.compressor_linear_coeffcient * (m.elec[1] + m.elec[2] + m.elec[3]) - m.compressor_linear_coeffcient  * m.elec[4] - m.compressor_fixed_cost * (m.purify_H2.binary_indicator_var + m.recycle_hydrogen.binary_indicator_var + m.absorber_hydrogen.binary_indicator_var) - m.compressor_fixed_cost * m.recycle_methane_membrane.binary_indicator_var - sum((m.electricity_cost * m.elec[comp]) for comp in m.comp) - (m.adiabtic_reactor_fixed_cost * m.adiabatic_reactor.binary_indicator_var + m.adiabtic_reactor_linear_coeffcient * m.rctvol[1]) -  (m.isothermal_reactor_fixed_cost * m.isothermal_reactor.binary_indicator_var + m.isothermal_reactor_linear_coeffcient * m.rctvol[2]) - m.cooling_cost/1000 * m.q[2] - (m.stabilizing_column_fixed_cost * m.methane_distillation_column.binary_indicator_var +m.stabilizing_column_linear_coeffcient * m.ndist[1]) - (m.benzene_column_fixed_cost+ m.benzene_column_linear_coeffcient  * m.ndist[2]) - (m.toluene_column_fixed_cost * m.toluene_distillation_column.binary_indicator_var + m.toluene_column_linear_coeffcient * m.ndist[3]) - (m.membrane_seperator_fixed_cost * m.purify_H2.binary_indicator_var + m.membrane_seperator_linear_coeffcient * m.f[3]) - (m.membrane_seperator_fixed_cost * m.recycle_methane_membrane.binary_indicator_var + m.membrane_seperator_linear_coeffcient * m.f[54]) - (m.abs_fixed_cost * m.absorber_hydrogen.binary_indicator_var + m.abs_linear_coeffcient * m.nabs[1]) - ( m.fuel_cost * m.qfuel[1] + m.furnace_linear_coeffcient* m.qfuel[1] ) - sum(m.cooling_cost * m.qc[hec] for hec in m.hec) - sum(m.heating_cost * m.qh[heh] for heh in m.heh) - m.furnace_fixed_cost  
     m.obj = Objective(rule = profits_from_paper, sense=maximize)
     # def profits_GAMS_file(m):
 
     #     "there are several differences between the data from GAMS file and the paper: 1. all the compressor share the same fixed and linear cost in paper but in GAMS they have different fixed and linear cost in GAMS file. 2. the fixed cost for absorber in GAMS file is 3.0 but in the paper is 13.0, but they are getting the same results 3. the electricity cost is not the same"
 
-    #     return 510. * (- m.h2_feed_cost * m.f[1] - m.toluene_feed_cost * (m.f[66] + m.f[67]) + m.benzene_product * m.f[31] + m.diphenyl_product * m.f[35] + m.hydrogen_purge_value * (m.fc[4, 'h2'] + m.fc[28, 'h2'] + m.fc[53, 'h2'] + m.fc[55, 'h2']) + m.meathane_purge_value * (m.fc[4, 'ch4'] + m.fc[28, 'ch4'] + m.fc[53, 'ch4'] + m.fc[55, 'ch4'])) - m.compressor_linear_coeffcient * (m.elec[1] + m.elec[2] + m.elec[3]) - m.compressor_linear_coeffcient_4  * m.elec[4] - m.compressor_fixed_cost * (m.purify_H2.indicator_var + m.recycle_hydrogen.indicator_var + m.absorber_hydrogen.indicator_var) - m.compressor_fixed_cost_4 * m.recycle_methane_membrane.indicator_var - sum((m.costelec * m.elec[comp]) for comp in m.comp) - (m.adiabtic_reactor_fixed_cost * m.adiabatic_reactor.indicator_var + m.adiabtic_reactor_linear_coeffcient * m.rctvol[1]) -  (m.isothermal_reactor_fixed_cost * m.isothermal_reactor.indicator_var + m.isothermal_reactor_linear_coeffcient * m.rctvol[2]) - m.cooling_cost/1000 * m.q[2] - (m.stabilizing_column_fixed_cost * m.methane_distillation_column.indicator_var +m.stabilizing_column_linear_coeffcient * m.ndist[1]) - (m.benzene_column_fixed_cost + m.benzene_column_linear_coeffcient  * m.ndist[2]) - (m.toluene_column_fixed_cost * m.toluene_distillation_column.indicator_var + m.toluene_column_linear_coeffcient * m.ndist[3]) - (m.membrane_seperator_fixed_cost * m.purify_H2.indicator_var + m.membrane_seperator_linear_coeffcient * m.f[3]) - (m.membrane_seperator_fixed_cost * m.recycle_methane_membrane.indicator_var + m.membrane_seperator_linear_coeffcient * m.f[54]) - (3.0 * m.absorber_hydrogen.indicator_var + m.abs_linear_coeffcient * m.nabs[1]) - (m.fuel_cost * m.qfuel[1] + m.furnace_linear_coeffcient* m.qfuel[1]) - sum(m.cooling_cost * m.qc[hec] for hec in m.hec) - sum(m.heating_cost * m.qh[heh] for heh in m.heh) - m.furnace_fixed_cost
+    #     return 510. * (- m.h2_feed_cost * m.f[1] - m.toluene_feed_cost * (m.f[66] + m.f[67]) + m.benzene_product * m.f[31] + m.diphenyl_product * m.f[35] + m.hydrogen_purge_value * (m.fc[4, 'h2'] + m.fc[28, 'h2'] + m.fc[53, 'h2'] + m.fc[55, 'h2']) + m.meathane_purge_value * (m.fc[4, 'ch4'] + m.fc[28, 'ch4'] + m.fc[53, 'ch4'] + m.fc[55, 'ch4'])) - m.compressor_linear_coeffcient * (m.elec[1] + m.elec[2] + m.elec[3]) - m.compressor_linear_coeffcient_4  * m.elec[4] - m.compressor_fixed_cost * (m.purify_H2.binary_indicator_var + m.recycle_hydrogen.binary_indicator_var + m.absorber_hydrogen.binary_indicator_var) - m.compressor_fixed_cost_4 * m.recycle_methane_membrane.binary_indicator_var - sum((m.costelec * m.elec[comp]) for comp in m.comp) - (m.adiabtic_reactor_fixed_cost * m.adiabatic_reactor.binary_indicator_var + m.adiabtic_reactor_linear_coeffcient * m.rctvol[1]) -  (m.isothermal_reactor_fixed_cost * m.isothermal_reactor.binary_indicator_var + m.isothermal_reactor_linear_coeffcient * m.rctvol[2]) - m.cooling_cost/1000 * m.q[2] - (m.stabilizing_column_fixed_cost * m.methane_distillation_column.binary_indicator_var +m.stabilizing_column_linear_coeffcient * m.ndist[1]) - (m.benzene_column_fixed_cost + m.benzene_column_linear_coeffcient  * m.ndist[2]) - (m.toluene_column_fixed_cost * m.toluene_distillation_column.binary_indicator_var + m.toluene_column_linear_coeffcient * m.ndist[3]) - (m.membrane_seperator_fixed_cost * m.purify_H2.binary_indicator_var + m.membrane_seperator_linear_coeffcient * m.f[3]) - (m.membrane_seperator_fixed_cost * m.recycle_methane_membrane.binary_indicator_var + m.membrane_seperator_linear_coeffcient * m.f[54]) - (3.0 * m.absorber_hydrogen.binary_indicator_var + m.abs_linear_coeffcient * m.nabs[1]) - (m.fuel_cost * m.qfuel[1] + m.furnace_linear_coeffcient* m.qfuel[1]) - sum(m.cooling_cost * m.qc[hec] for hec in m.hec) - sum(m.heating_cost * m.qh[heh] for heh in m.heh) - m.furnace_fixed_cost
     # m.obj = Objective(rule=profits_GAMS_file, sense=maximize)
 
     return m
@@ -1886,41 +1886,41 @@ def enumerate_solutions(m):
                     for Methane_product_selection in Methane_product_selections:
                         for Toluene_product_selection in Toluene_product_selections:
                             if H2_treatment == 'purify':
-                                m.purify_H2.indicator_var.fix(1)
-                                m.no_purify_H2.indicator_var.fix(0)
+                                m.purify_H2.indicator_var.fix(True)
+                                m.no_purify_H2.indicator_var.fix(False)
                             else:
-                                m.purify_H2.indicator_var.fix(0)
-                                m.no_purify_H2.indicator_var.fix(1)
+                                m.purify_H2.indicator_var.fix(False)
+                                m.no_purify_H2.indicator_var.fix(True)
                             if Reactor_selection == 'adiabatic_reactor':
-                                m.adiabatic_reactor.indicator_var.fix(1)
-                                m.isothermal_reactor.indicator_var.fix(0)
+                                m.adiabatic_reactor.indicator_var.fix(True)
+                                m.isothermal_reactor.indicator_var.fix(False)
                             else:
-                                m.adiabatic_reactor.indicator_var.fix(0)
-                                m.isothermal_reactor.indicator_var.fix(1)
+                                m.adiabatic_reactor.indicator_var.fix(False)
+                                m.isothermal_reactor.indicator_var.fix(True)
                             if Methane_recycle_selection == 'recycle_membrane':
-                                m.recycle_methane_purge.indicator_var.fix(0)
-                                m.recycle_methane_membrane.indicator_var.fix(1)
+                                m.recycle_methane_purge.indicator_var.fix(False)
+                                m.recycle_methane_membrane.indicator_var.fix(True)
                             else:
-                                m.recycle_methane_purge.indicator_var.fix(1)
-                                m.recycle_methane_membrane.indicator_var.fix(0)
+                                m.recycle_methane_purge.indicator_var.fix(True)
+                                m.recycle_methane_membrane.indicator_var.fix(False)
                             if Absorber_recycle_selection == 'yes_absorber':
-                                m.absorber_hydrogen.indicator_var.fix(1)
-                                m.recycle_hydrogen.indicator_var.fix(0)
+                                m.absorber_hydrogen.indicator_var.fix(True)
+                                m.recycle_hydrogen.indicator_var.fix(False)
                             else:
-                                m.absorber_hydrogen.indicator_var.fix(0)
-                                m.recycle_hydrogen.indicator_var.fix(1)
+                                m.absorber_hydrogen.indicator_var.fix(False)
+                                m.recycle_hydrogen.indicator_var.fix(True)
                             if Methane_product_selection == 'methane_column':
-                                m.methane_flash_separation.indicator_var.fix(0)
-                                m.methane_distillation_column.indicator_var.fix(1)
+                                m.methane_flash_separation.indicator_var.fix(False)
+                                m.methane_distillation_column.indicator_var.fix(True)
                             else:
-                                m.methane_flash_separation.indicator_var.fix(1)
-                                m.methane_distillation_column.indicator_var.fix(0)
+                                m.methane_flash_separation.indicator_var.fix(True)
+                                m.methane_distillation_column.indicator_var.fix(False)
                             if Toluene_product_selection == 'toluene_column':
-                                m.toluene_flash_separation.indicator_var.fix(0)
-                                m.toluene_distillation_column.indicator_var.fix(1)
+                                m.toluene_flash_separation.indicator_var.fix(False)
+                                m.toluene_distillation_column.indicator_var.fix(True)
                             else:
-                                m.toluene_flash_separation.indicator_var.fix(1)
-                                m.toluene_distillation_column.indicator_var.fix(0)
+                                m.toluene_flash_separation.indicator_var.fix(True)
+                                m.toluene_distillation_column.indicator_var.fix(False)
                             opt = SolverFactory('gdpopt')
                             res = opt.solve(m,tee =False,
                                             strategy = 'LOA',
@@ -1941,27 +1941,27 @@ def show_decision(m):
     '''
     print indicator variable value
     '''
-    if value(m.purify_H2.indicator_var) == 1:
+    if value(m.purify_H2.binary_indicator_var) == 1:
         print("purify inlet H2")
     else:
         print("no purify inlet H2")
-    if value(m.adiabatic_reactor.indicator_var) == 1:
+    if value(m.adiabatic_reactor.binary_indicator_var) == 1:
         print("adiabatic reactor")
     else:
         print("isothermal reactor")
-    if value(m.recycle_methane_membrane.indicator_var) == 1:
+    if value(m.recycle_methane_membrane.binary_indicator_var) == 1:
         print("recycle_membrane")
     else:
         print("methane purge")
-    if value(m.absorber_hydrogen.indicator_var) == 1:
+    if value(m.absorber_hydrogen.binary_indicator_var) == 1:
         print("yes_absorber")
     else:
         print("no_absorber")
-    if value(m.methane_distillation_column.indicator_var) == 1:
+    if value(m.methane_distillation_column.binary_indicator_var) == 1:
         print("methane_column")
     else:
         print("methane_flash")
-    if value(m.toluene_distillation_column.indicator_var) == 1:
+    if value(m.toluene_distillation_column.binary_indicator_var) == 1:
         print("toluene_column")
     else:
         print("toluene_flash")

--- a/gdplib/hda/__init__.py
+++ b/gdplib/hda/__init__.py
@@ -1,3 +1,3 @@
-from .HDA-GDP-gdpopt import HDA_model
+from .HDA_GDP_gdpopt import HDA_model
 
 __all__ = ['HDA_model']

--- a/gdplib/kaibel/kaibel_init.py
+++ b/gdplib/kaibel/kaibel_init.py
@@ -29,7 +29,7 @@ from __future__ import division
 
 from pyomo.environ import (exp, log10, minimize, NonNegativeReals, Objective, RangeSet, SolverFactory, value, Var)
 
-from kaibel_prop import get_model_with_properties
+from gdplib.kaibel.kaibel_prop import get_model_with_properties
 
 
 def initialize_kaibel():

--- a/gdplib/kaibel/kaibel_side_flash.py
+++ b/gdplib/kaibel/kaibel_side_flash.py
@@ -47,13 +47,9 @@ def calc_side_feed_flash(m):
     
     @msf.Constraint(doc="Vapor fraction")
     def _algq(msf):
-        val = sum(m.xfi[nc] * (1 - msf.Keqf[nc]) / \
+        return sum(m.xfi[nc] * (1 - msf.Keqf[nc]) / \
                   (1 + msf.q * (msf.Keqf[nc] - 1))
-                  for nc in msf.nc)
-        if val == 0:
-            return Constraint.Skip 
-        else:
-            return val == 0
+                  for nc in msf.nc) == 0
 
         
     @msf.Constraint(msf.nc,

--- a/gdplib/kaibel/main_gdp.py
+++ b/gdplib/kaibel/main_gdp.py
@@ -76,6 +76,7 @@ def main():
 
 
     results = SolverFactory('gdpopt').solve(m,
+                                            strategy='LOA',
                                             tee=True,
                                             time_limit = 3600, 
                                             mip_solver='gams',

--- a/gdplib/logical/positioning.py
+++ b/gdplib/logical/positioning.py
@@ -193,7 +193,7 @@ def build_model():
             []
         ]
     for i in m.consumers:
-        m.Y[i].set_binary_var(m.d[i].disjuncts[0].indicator_var)
+        m.Y[i].associate_binary_var(m.d[i].disjuncts[0].binary_indicator_var)
     for k in m.locations:
         lb, ub = location_bounds[k]
         m.x[k].setlb(lb)
@@ -206,7 +206,7 @@ def build_model():
     m.c5 = Constraint(expr=0.25 * m.x[2] + 1.05 * m.x[4] - 0.3 * m.x[5] >= 4.5)
 
     m.obj = Objective(
-        expr=10 * m.U - sum(m.fixed_profit[i] * m.Y[i].as_binary() for i in m.consumers) + 0.6 * m.x[1] ** 2 - 0.9 * m.x[
+        expr=10 * m.U - sum(m.fixed_profit[i] * m.Y[i].get_associated_binary() for i in m.consumers) + 0.6 * m.x[1] ** 2 - 0.9 * m.x[
             2] - 0.5 * m.x[3] + 0.1 * m.x[4] ** 2 + m.x[5])
 
     return m

--- a/gdplib/logical/spectralog.py
+++ b/gdplib/logical/spectralog.py
@@ -80,7 +80,8 @@ def build_model():
         ]
 
     for k, i in m.compounds * m.wave_number:
-        m.Y[k, i].set_binary_var(m.d[k, i].disjuncts[0].indicator_var)
+        m.Y[k, i].associate_binary_var(
+            m.d[k, i].disjuncts[0].binary_indicator_var)
 
     @m.Constraint(m.spectra_data)
     def eq1(m, j):

--- a/gdplib/mod_hens/common.py
+++ b/gdplib/mod_hens/common.py
@@ -289,7 +289,7 @@ def build_model(use_cafaro_approximation, num_stages):
             ) ** (1 / 3))
 
     def _exchanger_exists(disj, hot, cold, stg):
-        disj.indicator_var.value = 1
+        disj.indicator_var.value = True
 
         # Log mean temperature difference calculation
         disj.LMTD_calc = Constraint(
@@ -336,7 +336,7 @@ def build_model(use_cafaro_approximation, num_stages):
                 - m.stage_entry_T[cold, stg])
 
     def _exchanger_absent(disj, hot, cold, stg):
-        disj.indicator_var.value = 0
+        disj.indicator_var.value = False
         disj.no_match_exchanger_cost = Constraint(
             expr=m.exchanger_area_cost[stg, hot, cold] == 0)
         disj.no_match_exchanger_area = Constraint(
@@ -368,15 +368,15 @@ def build_model(use_cafaro_approximation, num_stages):
     for hot, cold in m.valid_matches:
         if hot not in m.utility_streams:
             m.exchanger_exists[hot, cold, 1].deactivate()
-            m.exchanger_absent[hot, cold, 1].indicator_var.fix(1)
+            m.exchanger_absent[hot, cold, 1].indicator_var.fix(True)
         if cold not in m.utility_streams:
             m.exchanger_exists[hot, cold, num_stages].deactivate()
-            m.exchanger_absent[hot, cold, num_stages].indicator_var.fix(1)
+            m.exchanger_absent[hot, cold, num_stages].indicator_var.fix(True)
     # Exclude utility-stream matches in middle stages
     for hot, cold, stg in m.valid_matches * (m.stages - [1, num_stages]):
         if hot in m.utility_streams or cold in m.utility_streams:
             m.exchanger_exists[hot, cold, stg].deactivate()
-            m.exchanger_absent[hot, cold, stg].indicator_var.fix(1)
+            m.exchanger_absent[hot, cold, stg].indicator_var.fix(True)
 
     @m.Expression(m.utility_streams)
     def utility_cost(m, strm):

--- a/gdplib/mod_hens/modular_discrete.py
+++ b/gdplib/mod_hens/modular_discrete.py
@@ -24,7 +24,7 @@ def build_require_modular(cafaro_approx, num_stages):
     # Require modular
     for hot, cold, stg in m.valid_matches * m.stages:
         disj = m.exchanger_exists[hot, cold, stg]
-        disj.modular.indicator_var.fix(1)
+        disj.modular.indicator_var.fix(True)
         disj.conventional.deactivate()
 
     for hot, cold in m.valid_matches:

--- a/gdplib/mod_hens/modular_integer.py
+++ b/gdplib/mod_hens/modular_integer.py
@@ -21,7 +21,7 @@ def build_single_module(cafaro_approx, num_stages):
     # Require modular
     for hot, cold, stg in m.valid_matches * m.stages:
         disj = m.exchanger_exists[hot, cold, stg]
-        disj.modular.indicator_var.fix(1)
+        disj.modular.indicator_var.fix(True)
         disj.conventional.deactivate()
 
     # Must choose only one type of module

--- a/gdplib/modprodnet/distributed.py
+++ b/gdplib/modprodnet/distributed.py
@@ -101,7 +101,7 @@ def build_modular_model():
     m.modular_setup_time = Param(initialize=3)
     m.modular_move_time = Param(initialize=3)
     m.markets = RangeSet(5)
-    m.modular_sites = RangeSet(2)
+    m.modular_sites = RangeSet(1, 3)
     m.site_pairs = Set(
         initialize=m.modular_sites * m.modular_sites,
         filter=lambda _, x, y: not x == y)
@@ -219,17 +219,17 @@ def build_modular_model():
     @m.Constraint(m.modular_sites, doc="Symmetry breaking for site activation")
     def site_active_ordering(m, site):
         if site + 1 <= max(m.modular_sites):
-            return (m.site_active[site].indicator_var >=
-                    m.site_active[site + 1].indicator_var)
+            return (m.site_active[site].binary_indicator_var >=
+                    m.site_active[site + 1].binary_indicator_var)
         else:
             return Constraint.NoConstraint
 
     @m.Disjunct(m.unique_site_pairs)
     def pair_active(disj, site1, site2):
         disj.site1_active = Constraint(
-            expr=m.site_active[site1].indicator_var == 1)
+            expr=m.site_active[site1].binary_indicator_var == 1)
         disj.site2_active = Constraint(
-            expr=m.site_active[site2].indicator_var == 1)
+            expr=m.site_active[site2].binary_indicator_var == 1)
         disj.site_distance_calc = Constraint(
             expr=m.dist_to_site[site1, site2] == sqrt(
                 m.sqr_scaled_dist_to_site[site1, site2]) * 150)
@@ -246,9 +246,9 @@ def build_modular_model():
     @m.Disjunct(m.unique_site_pairs)
     def pair_inactive(disj, site1, site2):
         disj.site1_inactive = Constraint(
-            expr=m.site_active[site1].indicator_var == 0)
+            expr=m.site_active[site1].binary_indicator_var == 0)
         disj.site2_inactive = Constraint(
-            expr=m.site_active[site2].indicator_var == 0)
+            expr=m.site_active[site2].binary_indicator_var == 0)
 
         disj.no_module_transfer = Constraint(
             expr=sum(m.modules_transferred[site1, site2, mo]
@@ -266,7 +266,7 @@ def build_modular_model():
     @m.Disjunct(m.modular_sites, m.markets)
     def product_route_active(disj, site, mkt):
         disj.site_active = Constraint(
-            expr=m.site_active[site].indicator_var == 1)
+            expr=m.site_active[site].binary_indicator_var == 1)
 
         @disj.Constraint()
         def market_distance_calculation(site_disj):
@@ -298,7 +298,7 @@ def build_modular_model():
             for mo in m.months))
 
     m.fixed_shipment_cost = Expression(
-        expr=sum(m.product_route_active[site, mkt].indicator_var *
+        expr=sum(m.product_route_active[site, mkt].binary_indicator_var *
                  m.route_fixed_cost
                  for site in m.modular_sites for mkt in m.markets))
 
@@ -385,7 +385,8 @@ if __name__ == "__main__":
             site, m.site_x[site].value, m.site_y[site].value))
         print("  Supplies markets {}".format(tuple(
             mkt for mkt in m.markets
-            if m.product_route_active[site, mkt].indicator_var.value == 1)))
+            if m.product_route_active[site, 
+                                      mkt].binary_indicator_var.value == 1)))
 
 
     if res.solver.termination_condition is not TerminationCondition.optimal:
@@ -403,7 +404,7 @@ if __name__ == "__main__":
             'site%s' % site, (m.site_x[site].value, m.site_y[site].value),
              (m.site_x[site].value + 2, m.site_y[site].value + 0))
     for site, mkt in m.modular_sites * m.markets:
-        if m.product_route_active[site, mkt].indicator_var.value == 1:
+        if m.product_route_active[site, mkt].binary_indicator_var.value == 1:
             plt.arrow(m.site_x[site].value, m.site_y[site].value,
                       m.mkt_x[mkt] - m.site_x[site].value,
                       m.mkt_y[mkt] - m.site_y[site].value,

--- a/gdplib/stranded_gas/model.py
+++ b/gdplib/stranded_gas/model.py
@@ -9,7 +9,7 @@ from pyomo.environ import (
     RangeSet, Set, SolverFactory, Suffix, TransformationFactory, Var, exp, log,
     sqrt, summation, value
 )
-from .util import alphanum_sorted
+from gdplib.stranded_gas.util import alphanum_sorted
 from pyomo.environ import TerminationCondition as tc
 
 

--- a/gdplib/stranded_gas/model.py
+++ b/gdplib/stranded_gas/model.py
@@ -343,7 +343,7 @@ def build_model():
     @m.Expression(m.well_clusters, m.potential_sites, doc="MM$")
     def pipeline_construction_cost(m, well, site):
         return (m.pipeline_unit_cost * m.distance[well, site]
-                * m.pipeline_exists[well, site].indicator_var)
+                * m.pipeline_exists[well, site].binary_indicator_var)
 
     # Module transport cost
     @m.Expression(m.site_pairs, doc="MM$")
@@ -408,4 +408,4 @@ if __name__ == "__main__":
         m.modules_transferred[mtype, :, :, :].fix(0)
         m.modules_purchased[mtype, :, :].fix(0)
         m.mtype_exists[mtype].deactivate()
-        m.mtype_absent[mtype].indicator_var.fix(1)
+        m.mtype_absent[mtype].binary_indicator_var.fix(1)

--- a/gdplib/syngas/syngas_adapted.py
+++ b/gdplib/syngas/syngas_adapted.py
@@ -765,7 +765,7 @@ if __name__ == "__main__":
     #     # solver="cplex", add_options=['GAMS_MODEL.optfile=1;', '$onecho > cplex.opt', 'iis=1', '$offecho'],
     # )
     result = SolverFactory('gdpopt').solve(
-        m, tee=True, mip_solver='gams',
+        m, strategy='LOA', tee=True, mip_solver='gams',
         nlp_solver='gams', nlp_solver_args=dict(solver='scip', add_options=['option optcr=0;']),
         minlp_solver='gams', minlp_solver_args=dict(solver='baron', add_options=['option optcr=0;'])
     )


### PR DESCRIPTION
This PR updates the models to account for the current logical expression system in pyomo, as well as the fact that GDPopt now requires that an algorithm be specified. In addition, some models were not importable either because of dashes in the filename, because of relative imports, or because of hard-coded data files. This updates those so that they can be instantiated and run outside of the gdplib directory. Last, this updates the use of `indicator_var` to comply with the fact that it is now Boolean, and adds the use of `binary_indicator_var` when it is the binary that is needed.