### PR TITLE
Fix Typo in Parameter Name

### DIFF
--- a/gdplib/med_term_purchasing/med_term_purchasing.py
+++ b/gdplib/med_term_purchasing/med_term_purchasing.py
@@ -141,7 +141,7 @@ def build_model():
     # pd1(j, t) in GAMS
     model.RegPrice_Discount = Param(
         model.Streams,
-        model.TimePeriod,
+        model.TimePeriods,
         doc='Price for quantities less than min amount under discount contract',
     )
 

--- a/gdplib/med_term_purchasing/med_term_purchasing.py
+++ b/gdplib/med_term_purchasing/med_term_purchasing.py
@@ -339,7 +339,7 @@ def build_model():
         model.Streams,
         model.TimePeriods,
         initialize=getCostUBs,
-        DOC='Upper bound on cost of discount contract',
+        doc='Upper bound on cost of discount contract',
     )
     model.CostUB_Bulk = Param(
         model.Streams,


### PR DESCRIPTION
# Fix #32 
Fixed a typo in the parameter name `model.TimePeriod` to `model.TimePeriods` in the `build_model()` function. This ensures that the correct parameter is used for calculating the price for quantities under a discount contract. Additionally, the documentation for the `getCostUBs()` function has been updated to fix a typo in the word "DOC" to "doc".

I believe this work would resolve the issue https://github.com/SECQUOIA/gdplib/issues/34 .