### PR TITLE
Update typos.toml

### DIFF
--- a/.github/workflows/typos.toml
+++ b/.github/workflows/typos.toml
@@ -3,3 +3,4 @@
 hda = "hda"
 HDA = "HDA"
 equil = "equil"
+gam = "gam"


### PR DESCRIPTION
Add `gam`, which appears in `/gdplib/hda/HDA_GDP_gdpopt.py`, to the `typos.toml` file to skip the spelling check.