### PR TITLE
Remove associate and unused variables

### DIFF
--- a/gdplib/ex1_linan_2023/ex1_linan_2023.py
+++ b/gdplib/ex1_linan_2023/ex1_linan_2023.py
@@ -130,9 +130,9 @@ def build_model():
 
     m.Disjunction1 = Disjunction(rule=Disjunction1, xor=False)
 
-    # Associate boolean variables to disjuncts
-    for n1 in m.set1:
-        m.Y1[n1].associate_binary_var(m.Y1_disjunct[n1].indicator_var)
+    # # Associate boolean variables to disjuncts
+    # for n1 in m.set1:
+    #     m.Y1[n1].associate_binary_var(m.Y1_disjunct[n1].indicator_var)
 
     # Second disjunction
     def build_disjuncts2(m, set2):  # Disjuncts for second Boolean variable
@@ -188,9 +188,9 @@ def build_model():
 
     m.Disjunction2 = Disjunction(rule=Disjunction2, xor=False)
 
-    # Associate boolean variables to disjuncts
-    for n2 in m.set2:
-        m.Y2[n2].associate_binary_var(m.Y2_disjunct[n2].indicator_var)
+    # # Associate boolean variables to disjuncts
+    # for n2 in m.set2:
+    #     m.Y2[n2].associate_binary_var(m.Y2_disjunct[n2].indicator_var)
 
     # Logical constraints
 

--- a/gdplib/ex1_linan_2023/ex1_linan_2023.py
+++ b/gdplib/ex1_linan_2023/ex1_linan_2023.py
@@ -127,10 +127,6 @@ def build_model():
 
     m.Disjunction1 = Disjunction(rule=Disjunction1, xor=False)
 
-    # # Associate boolean variables to disjuncts
-    # for n1 in m.set1:
-    #     m.Y1[n1].associate_binary_var(m.Y1_disjunct[n1].indicator_var)
-
     # Second disjunction
     def build_disjuncts2(m, set2):  # Disjuncts for second Boolean variable
         """
@@ -184,10 +180,6 @@ def build_model():
         return [m.Y2_disjunct[j] for j in m.set2]
 
     m.Disjunction2 = Disjunction(rule=Disjunction2, xor=False)
-
-    # # Associate boolean variables to disjuncts
-    # for n2 in m.set2:
-    #     m.Y2[n2].associate_binary_var(m.Y2_disjunct[n2].indicator_var)
 
     # Logical constraints
 

--- a/gdplib/ex1_linan_2023/ex1_linan_2023.py
+++ b/gdplib/ex1_linan_2023/ex1_linan_2023.py
@@ -40,9 +40,6 @@ def build_model():
     m.sub1 = pyo.Set(initialize=[3], within=m.set1)
 
     # Variables
-    m.Y1 = pyo.BooleanVar(m.set1, doc="Boolean variable associated to set 1")
-    m.Y2 = pyo.BooleanVar(m.set2, doc="Boolean variable associated to set 2")
-
     m.alpha = pyo.Var(
         within=pyo.Reals, bounds=(-0.1, 0.4), doc="continuous variable alpha"
     )
@@ -209,7 +206,7 @@ def build_model():
         Pyomo.LogicalConstraint
             Logical constraint that make Y1 to be true for only one element
         """
-        return pyo.exactly(1, m.Y1)
+        return pyo.exactly(1, [m.Y1_disjunct[n].indicator_var for n in m.set1])
 
     m.oneY1 = pyo.LogicalConstraint(rule=select_one_Y1)
 
@@ -228,7 +225,7 @@ def build_model():
         Pyomo.LogicalConstraint
             Logical constraint that make Y2 to be true for only one element
         """
-        return pyo.exactly(1, m.Y2)
+        return pyo.exactly(1,[m.Y2_disjunct[n].indicator_var for n in m.set2])
 
     m.oneY2 = pyo.LogicalConstraint(rule=select_one_Y2)
 
@@ -248,7 +245,7 @@ def build_model():
         Pyomo.LogicalConstraint
             Logical constraint that defines an infeasible region on Y1[3]
         """
-        return pyo.land([pyo.lnot(m.Y1[j]) for j in m.sub1])
+        return pyo.land([pyo.lnot(m.Y1_disjunct[j].indicator_var) for j in m.sub1])
 
     m.infeasR = pyo.LogicalConstraint(rule=infeasR_rule)
 

--- a/gdplib/ex1_linan_2023/ex1_linan_2023.py
+++ b/gdplib/ex1_linan_2023/ex1_linan_2023.py
@@ -217,7 +217,7 @@ def build_model():
         Pyomo.LogicalConstraint
             Logical constraint that make Y2 to be true for only one element
         """
-        return pyo.exactly(1,[m.Y2_disjunct[n].indicator_var for n in m.set2])
+        return pyo.exactly(1, [m.Y2_disjunct[n].indicator_var for n in m.set2])
 
     m.oneY2 = pyo.LogicalConstraint(rule=select_one_Y2)
 


### PR DESCRIPTION
This pull request removes the `associate_binary_var` method call and the unused variables `m.Y1` and `m.Y2`. These changes simplify the code and remove unnecessary functionality.

Linan's codes involve associating the Boolean variable with Binary variable. using the indicator var would be helpful for the code to excecute logic-based Algorithms.