### PR TITLE
Fix grammar in kaibel_init docstring

### DIFF
--- a/gdplib/kaibel/kaibel_init.py
+++ b/gdplib/kaibel/kaibel_init.py
@@ -3,8 +3,8 @@
                             temperature values.
             (written by E. Soraya Rawlings, esoraya@rwlngs.net)
 
-The separation of four components require a sequence of at least three distillation
-columns. Here, we calculate the minimum number of theoretical trays for the three
+The separation of four components requires a sequence of at least three distillation columns.
+Here, we calculate the minimum number of theoretical trays for the three
 columns. The sequence is shown in Figure 2.
 
          COLUMN 1              COLUMN 2              COLUMN 3


### PR DESCRIPTION
## Summary
- fix grammar in the introduction of `kaibel_init.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6886fb5635fc83278f73a14265737f2e