### PR TITLE
Improve build_model tests to fail on errors

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -37,7 +37,7 @@ gdplib = { path = ".", editable = true }
 [tasks]
 test = "pytest tests/ -v --tb=short"
 test-imports = "pytest tests/test_module_imports.py -v --tb=short"
-test-methanol = "pytest tests/test_module_imports.py::TestModelConstruction::test_methanol_model_construction -v --tb=short"
+test-methanol = "pytest 'tests/test_module_imports.py::TestModelConstruction::test_model_construction[methanol]' -v --tb=short"
 lint-black = "black -S -C --target-version py310 --check --diff ."
 lint-flake8-critical = "flake8 gdplib/ --count --select=E9,F63,F7,F82 --show-source --statistics"
 lint-flake8 = "flake8 gdplib/ --count --exit-zero --max-complexity=10 --max-line-length=88 --statistics"

--- a/tests/build_model_test_utils.py
+++ b/tests/build_model_test_utils.py
@@ -1,0 +1,35 @@
+import inspect
+
+
+def get_required_build_model_parameters(build_func):
+    """Return required parameters that prevent zero-argument construction."""
+    try:
+        signature = inspect.signature(build_func)
+    except (TypeError, ValueError):
+        return []
+
+    required_params = []
+    for name, param in signature.parameters.items():
+        if param.default is not inspect.Parameter.empty:
+            continue
+        if param.kind in (
+            inspect.Parameter.POSITIONAL_ONLY,
+            inspect.Parameter.POSITIONAL_OR_KEYWORD,
+            inspect.Parameter.KEYWORD_ONLY,
+        ):
+            required_params.append(name)
+    return required_params
+
+
+def is_missing_external_solver_error(error):
+    """Return whether an exception is caused by an unavailable optional solver."""
+    error_msg = str(error).lower()
+    return any(
+        pattern in error_msg
+        for pattern in (
+            "no executable found for solver",
+            "no 'gams' command",
+            "could not locate the 'ipopt' executable",
+            "ipopt executable",
+        )
+    )

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -68,7 +68,7 @@ class TestBasicFunctionality:
         except (ImportError, AttributeError):
             pytest.skip("biofuel module or build_model not available")
         except Exception as e:
-            pytest.skip(f"Model construction failed: {e}")
+            pytest.fail(f"Model construction raised unexpected error: {e}")
 
 
 # (Line intentionally left blank for clarity and to maintain spacing.)

--- a/tests/test_build_model_test_utils.py
+++ b/tests/test_build_model_test_utils.py
@@ -1,0 +1,35 @@
+from build_model_test_utils import (
+    get_required_build_model_parameters,
+    is_missing_external_solver_error,
+)
+
+
+def test_required_build_model_parameters_detects_required_arguments():
+    def build_model(case, *, formulation):
+        return None
+
+    assert get_required_build_model_parameters(build_model) == ["case", "formulation"]
+
+
+def test_required_build_model_parameters_ignores_optional_and_variadic_arguments():
+    def build_model(case=None, *args, **kwargs):
+        return None
+
+    assert get_required_build_model_parameters(build_model) == []
+
+
+def test_required_build_model_parameters_does_not_infer_from_type_error_text():
+    def build_model():
+        raise TypeError("missing internal data")
+
+    assert get_required_build_model_parameters(build_model) == []
+
+
+def test_missing_external_solver_error_detection():
+    assert is_missing_external_solver_error(
+        RuntimeError("No executable found for solver 'ipopt'")
+    )
+    assert is_missing_external_solver_error(
+        RuntimeError("No 'gams' command found on system PATH")
+    )
+    assert not is_missing_external_solver_error(TypeError("missing internal data"))

--- a/tests/test_comprehensive_coverage.py
+++ b/tests/test_comprehensive_coverage.py
@@ -15,6 +15,11 @@ import os
 # Add the gdplib directory to the path for testing
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
+from build_model_test_utils import (  # noqa: E402
+    get_required_build_model_parameters,
+    is_missing_external_solver_error,
+)
+
 
 class TestComprehensiveCoverage:
     """Comprehensive tests for all GDPlib models ensuring importability and runnability."""
@@ -54,6 +59,7 @@ class TestComprehensiveCoverage:
         import_results = {}
         build_model_results = {}
         execution_results = {}
+        unexpected_execution_failures = {}
 
         for module_name in self.ALL_GDPLIB_MODULES:
             # Test import
@@ -67,29 +73,32 @@ class TestComprehensiveCoverage:
             # Test build_model availability
             if hasattr(module, "build_model"):
                 build_model_results[module_name] = "✅ AVAILABLE"
+                build_func = getattr(module, "build_model")
+                required_params = get_required_build_model_parameters(build_func)
+                if required_params:
+                    execution_results[module_name] = (
+                        f"REQUIRES_PARAMETERS: {', '.join(required_params)}"
+                    )
+                    continue
 
                 # Test build_model execution
                 try:
-                    model = module.build_model()
+                    model = build_func()
                     if model is not None:
                         execution_results[module_name] = "✅ RUNNABLE"
                     else:
                         execution_results[module_name] = "⚠️  RETURNS_NULL"
                 except Exception as e:
                     # Handle solver dependency issues gracefully
-                    error_msg = str(e)
-                    if (
-                        "ipopt" in error_msg.lower()
-                        or "gams" in error_msg.lower()
-                        or "solver" in error_msg.lower()
-                    ):
+                    if is_missing_external_solver_error(e):
                         execution_results[module_name] = (
-                            f"⚠️  REQUIRES_SOLVER: {error_msg.split(':')[0] if ':' in error_msg else 'External solver'}"
+                            f"⚠️  REQUIRES_SOLVER: {str(e).split(':')[0] if ':' in str(e) else 'External solver'}"
                         )
                     else:
                         execution_results[module_name] = (
                             f"❌ EXECUTION_FAILED: {str(e)[:50]}..."
                         )
+                        unexpected_execution_failures[module_name] = str(e)
             else:
                 build_model_results[module_name] = "❌ MISSING"
                 execution_results[module_name] = "N/A"
@@ -132,6 +141,12 @@ class TestComprehensiveCoverage:
             )
 
         # Assert that we have good coverage
+        assert (
+            not unexpected_execution_failures
+        ), "Unexpected build_model failures: " + "; ".join(
+            f"{module_name}: {error}"
+            for module_name, error in sorted(unexpected_execution_failures.items())
+        )
         assert (
             successful_imports >= total_modules * 0.8
         ), f"Less than 80% of modules importable: {successful_imports}/{total_modules}"
@@ -179,6 +194,13 @@ class TestComprehensiveCoverage:
 
             build_func = getattr(module, "build_model")
 
+            required_params = get_required_build_model_parameters(build_func)
+            if required_params:
+                pytest.skip(
+                    f"{module_name}.build_model requires parameters: "
+                    f"{', '.join(required_params)}"
+                )
+
             # Try to build the model
             try:
                 model = build_func()
@@ -193,22 +215,11 @@ class TestComprehensiveCoverage:
                 components = list(model.component_objects())
                 assert len(components) > 0, f"{module_name} model has no components"
 
-            except TypeError as e:
-                # Some models might require parameters
-                if "required positional argument" in str(e) or "missing" in str(e):
-                    pytest.skip(f"{module_name}.build_model requires parameters: {e}")
-                else:
-                    pytest.fail(f"{module_name}.build_model failed with TypeError: {e}")
             except Exception as e:
                 # Handle solver dependency issues gracefully
-                error_msg = str(e)
-                if (
-                    "ipopt" in error_msg.lower()
-                    or "gams" in error_msg.lower()
-                    or "solver" in error_msg.lower()
-                ):
+                if is_missing_external_solver_error(e):
                     pytest.skip(
-                        f"{module_name} requires external solver: {error_msg[:100]}"
+                        f"{module_name} requires external solver: {str(e)[:100]}"
                     )
                 else:
                     pytest.fail(f"{module_name}.build_model failed: {e}")

--- a/tests/test_model_structure.py
+++ b/tests/test_model_structure.py
@@ -143,7 +143,9 @@ class TestModelFunctionality:
                         ), f"{module_name} model has no components"
 
                     except Exception as e:
-                        pytest.skip(f"{module_name} model construction failed: {e}")
+                        pytest.fail(
+                            f"{module_name} model construction raised unexpected error: {e}"
+                        )
             except ImportError:
                 pytest.skip(f"Module {module_name} not available")
 

--- a/tests/test_module_imports.py
+++ b/tests/test_module_imports.py
@@ -89,7 +89,18 @@ class TestModuleImports:
                             f"{module_name}.build_model requires specific arguments"
                         )
                 except Exception as e:
-                    pytest.skip(f"{module_name}.build_model failed with error: {e}")
+                    err_msg = str(e)
+                    if (
+                        "No executable found for solver" in err_msg
+                        or "No 'gams' command" in err_msg
+                    ):
+                        pytest.skip(
+                            f"{module_name}.build_model requires external solver: {e}"
+                        )
+                    else:
+                        pytest.fail(
+                            f"{module_name}.build_model raised unexpected error: {e}"
+                        )
         except ImportError:
             pytest.skip(f"Module {module_name} not available")
 
@@ -97,19 +108,32 @@ class TestModuleImports:
 class TestModelConstruction:
     """Test model construction for key modules."""
 
-    def test_cstr_model_construction(self):
-        """Test CSTR model construction specifically."""
-        try:
-            import gdplib.cstr
+    MODELS = ["cstr", "biofuel", "gdp_col", "methanol"]
 
-            model = gdplib.cstr.build_model()
+    @pytest.mark.parametrize("module_name", MODELS)
+    def test_model_construction(self, module_name):
+        """Ensure that selected models can be built successfully."""
+        try:
+            module = importlib.import_module(f"gdplib.{module_name}")
+
+            model = module.build_model()
             assert model is not None
-            # Basic model validation
             assert hasattr(model, "component_objects")
         except ImportError:
-            pytest.skip("CSTR module not available")
+            pytest.skip(f"{module_name} module not available")
         except Exception as e:
-            pytest.skip(f"CSTR model construction failed: {e}")
+            err_msg = str(e)
+            if (
+                "No executable found for solver" in err_msg
+                or "No 'gams' command" in err_msg
+            ):
+                pytest.skip(
+                    f"{module_name} model construction requires external solver: {e}"
+                )
+            else:
+                pytest.fail(
+                    f"{module_name} model construction raised unexpected error: {e}"
+                )
 
     def test_cstr_model_reformulates_with_bigm(self):
         """Test CSTR logical and GDP components reformulate with big-M."""
@@ -128,37 +152,3 @@ class TestModelConstruction:
 
         assert not any(model.component_data_objects(pyo.LogicalConstraint, active=True))
         assert not any(model.component_data_objects(Disjunction, active=True))
-
-    def test_biofuel_model_construction(self):
-        """Test biofuel model construction specifically."""
-        try:
-            import gdplib.biofuel
-
-            model = gdplib.biofuel.build_model()
-            assert model is not None
-            assert hasattr(model, "component_objects")
-        except ImportError:
-            pytest.skip("Biofuel module not available")
-        except Exception as e:
-            pytest.skip(f"Biofuel model construction failed: {e}")
-
-    def test_gdp_col_model_construction(self):
-        """Test GDP column model construction specifically."""
-        try:
-            import gdplib.gdp_col
-
-            model = gdplib.gdp_col.build_model()
-            assert model is not None
-            assert hasattr(model, "component_objects")
-        except ImportError:
-            pytest.skip("GDP column module not available")
-        except Exception as e:
-            pytest.skip(f"GDP column model construction failed: {e}")
-
-    def test_methanol_model_construction(self):
-        """Test methanol model construction specifically."""
-        from gdplib.methanol import build_model
-
-        model = build_model()
-        assert model is not None
-        assert hasattr(model, "component_objects")

--- a/tests/test_module_imports.py
+++ b/tests/test_module_imports.py
@@ -15,6 +15,11 @@ from pyomo.gdp import Disjunction
 # Add the gdplib directory to the path for testing
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
+from build_model_test_utils import (  # noqa: E402
+    get_required_build_model_parameters,
+    is_missing_external_solver_error,
+)
+
 
 class TestModuleImports:
     """Test that all gdplib modules can be imported individually."""
@@ -75,25 +80,18 @@ class TestModuleImports:
                     build_func
                 ), f"{module_name}.build_model is not callable"
 
-                # Try to call build_model without arguments first
+                required_params = get_required_build_model_parameters(build_func)
+                if required_params:
+                    pytest.skip(
+                        f"{module_name}.build_model requires parameters: "
+                        f"{', '.join(required_params)}"
+                    )
+
                 try:
                     model = build_func()
                     assert model is not None, f"{module_name}.build_model returned None"
-                except TypeError:
-                    # Some models might require arguments, try with empty args
-                    try:
-                        model = build_func(*[])
-                        assert model is not None
-                    except Exception:
-                        pytest.skip(
-                            f"{module_name}.build_model requires specific arguments"
-                        )
                 except Exception as e:
-                    err_msg = str(e)
-                    if (
-                        "No executable found for solver" in err_msg
-                        or "No 'gams' command" in err_msg
-                    ):
+                    if is_missing_external_solver_error(e):
                         pytest.skip(
                             f"{module_name}.build_model requires external solver: {e}"
                         )
@@ -122,11 +120,7 @@ class TestModelConstruction:
         except ImportError:
             pytest.skip(f"{module_name} module not available")
         except Exception as e:
-            err_msg = str(e)
-            if (
-                "No executable found for solver" in err_msg
-                or "No 'gams' command" in err_msg
-            ):
+            if is_missing_external_solver_error(e):
                 pytest.skip(
                     f"{module_name} model construction requires external solver: {e}"
                 )

--- a/tests/test_pip_installation.py
+++ b/tests/test_pip_installation.py
@@ -122,4 +122,4 @@ class TestPipInstallation:
             else:
                 pytest.fail(f"Import failed: {e}")
         except Exception as e:
-            pytest.skip(f"Model construction failed (may require solver): {e}")
+            pytest.fail(f"Model construction raised unexpected error: {e}")


### PR DESCRIPTION
## Summary
- ensure unexpected errors in build_model tests cause test failures
- apply the same logic to remaining tests that construct models
- skip tests when external solvers are missing
- consolidate model-specific construction tests into one parametrized check

## Testing
- `pytest -k module_imports -q`
- `pytest -k model_construction -q`


------
https://chatgpt.com/codex/tasks/task_b_6886fb5034388327a85683b7420a509d