### PR TITLE
Improve build_model tests to fail on errors

### DIFF
--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -68,7 +68,7 @@ class TestBasicFunctionality:
         except (ImportError, AttributeError):
             pytest.skip("biofuel module or build_model not available")
         except Exception as e:
-            pytest.skip(f"Model construction failed: {e}")
+            pytest.fail(f"Model construction raised unexpected error: {e}")
 
 
 # (Line intentionally left blank for clarity and to maintain spacing.)

--- a/tests/test_model_structure.py
+++ b/tests/test_model_structure.py
@@ -120,8 +120,8 @@ class TestModelFunctionality:
 
     def test_models_return_pyomo_objects(self):
         """Test that build_model functions return proper Pyomo model objects."""
-        # Test a few key models
-        test_modules = ["cstr", "biofuel", "gdp_col"]
+        # Test all available modules
+        test_modules = self.GDPLIB_MODULES
 
         for module_name in test_modules:
             try:
@@ -142,7 +142,9 @@ class TestModelFunctionality:
                         ), f"{module_name} model has no components"
 
                     except Exception as e:
-                        pytest.skip(f"{module_name} model construction failed: {e}")
+                        pytest.fail(
+                            f"{module_name} model construction raised unexpected error: {e}"
+                        )
             except ImportError:
                 pytest.skip(f"Module {module_name} not available")
 

--- a/tests/test_module_imports.py
+++ b/tests/test_module_imports.py
@@ -86,50 +86,48 @@ class TestModuleImports:
                             f"{module_name}.build_model requires specific arguments"
                         )
                 except Exception as e:
-                    pytest.skip(f"{module_name}.build_model failed with error: {e}")
+                    err_msg = str(e)
+                    if (
+                        "No executable found for solver" in err_msg
+                        or "No 'gams' command" in err_msg
+                    ):
+                        pytest.skip(
+                            f"{module_name}.build_model requires external solver: {e}"
+                        )
+                    else:
+                        pytest.fail(
+                            f"{module_name}.build_model raised unexpected error: {e}"
+                        )
         except ImportError:
             pytest.skip(f"Module {module_name} not available")
 
 
 class TestModelConstruction:
-    """Test model construction for key modules."""
+    """Test model construction for all GDPlib modules."""
 
-    def test_cstr_model_construction(self):
-        """Test CSTR model construction specifically."""
+    MODELS = TestModuleImports.GDPLIB_MODULES
+
+    @pytest.mark.parametrize("module_name", MODELS)
+    def test_model_construction(self, module_name):
+        """Ensure that selected models can be built successfully."""
         try:
-            import gdplib.cstr
+            module = importlib.import_module(f"gdplib.{module_name}")
 
-            model = gdplib.cstr.build_model()
-            assert model is not None
-            # Basic model validation
-            assert hasattr(model, "component_objects")
-        except ImportError:
-            pytest.skip("CSTR module not available")
-        except Exception as e:
-            pytest.skip(f"CSTR model construction failed: {e}")
-
-    def test_biofuel_model_construction(self):
-        """Test biofuel model construction specifically."""
-        try:
-            import gdplib.biofuel
-
-            model = gdplib.biofuel.build_model()
+            model = module.build_model()
             assert model is not None
             assert hasattr(model, "component_objects")
         except ImportError:
-            pytest.skip("Biofuel module not available")
+            pytest.skip(f"{module_name} module not available")
         except Exception as e:
-            pytest.skip(f"Biofuel model construction failed: {e}")
-
-    def test_gdp_col_model_construction(self):
-        """Test GDP column model construction specifically."""
-        try:
-            import gdplib.gdp_col
-
-            model = gdplib.gdp_col.build_model()
-            assert model is not None
-            assert hasattr(model, "component_objects")
-        except ImportError:
-            pytest.skip("GDP column module not available")
-        except Exception as e:
-            pytest.skip(f"GDP column model construction failed: {e}")
+            err_msg = str(e)
+            if (
+                "No executable found for solver" in err_msg
+                or "No 'gams' command" in err_msg
+            ):
+                pytest.skip(
+                    f"{module_name} model construction requires external solver: {e}"
+                )
+            else:
+                pytest.fail(
+                    f"{module_name} model construction raised unexpected error: {e}"
+                )

--- a/tests/test_pip_installation.py
+++ b/tests/test_pip_installation.py
@@ -122,4 +122,4 @@ class TestPipInstallation:
             else:
                 pytest.fail(f"Import failed: {e}")
         except Exception as e:
-            pytest.skip(f"Model construction failed (may require solver): {e}")
+            pytest.fail(f"Model construction raised unexpected error: {e}")


### PR DESCRIPTION
## Summary
- ensure unexpected errors in build_model tests cause test failures
- apply the same logic to remaining tests that construct models
- skip tests when external solvers are missing
- consolidate model-specific construction tests into one parametrized check
- expand model construction checks to all modules instead of just cstr, biofuel and gdp_col

## Testing
- `pytest -k module_imports -q`
- `pytest -k model_construction -q`


------
https://chatgpt.com/codex/tasks/task_b_6886fb5034388327a85683b7420a509d