### PR TITLE
[codex] Document build_model test expectations

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,6 +53,11 @@ These instructions apply to the whole repository.
   ```bash
   pytest tests/test_module_imports.py -v --tb=short
   ```
+- When changing `build_model()` tests, make unexpected construction failures
+  fail the test. Inspect builder signatures before calling models that may
+  require arguments; only skip required-argument builders or unavailable
+  optional solvers. Do not catch `Exception` or `TypeError` from
+  `build_model()` and turn it into a skip.
 - Match CI formatting and linting:
   ```bash
   black -S -C --target-version py310 --check --diff .


### PR DESCRIPTION
## Summary

- Add concise AGENTS.md guidance for `build_model()` tests.
- Capture the PR 94 lesson that unexpected construction errors should fail tests, while required-argument builders and unavailable optional solvers remain valid skips.

## Impact

This keeps future test changes from accidentally masking real model-construction regressions with broad exception handling.

## Validation

- `/home/bernalde/.pixi/bin/pixi run lint`
- `git diff --check`
