### PR TITLE
Fix Pyomo GDP deprecations

### DIFF
--- a/gdplib/gdp_col/__init__.py
+++ b/gdplib/gdp_col/__init__.py
@@ -20,11 +20,11 @@ def build_model():
     m.reboil_ratio.set_value(1.3)
     # Fix to be total condenser
     m.partial_cond.deactivate()
-    m.total_cond.indicator_var.fix(1)
+    m.total_cond.indicator_var.fix(True)
     # Give initial values of the tray existence/absence
     for t in m.conditional_trays:
-        m.tray[t].indicator_var.set_value(1)
-        m.no_tray[t].indicator_var.set_value(0)
+        m.tray[t].indicator_var.set_value(True)
+        m.no_tray[t].indicator_var.set_value(False)
 
     m.BigM = Suffix(direction=Suffix.LOCAL)
     m.BigM[None] = 100

--- a/gdplib/gdp_col/main.py
+++ b/gdplib/gdp_col/main.py
@@ -31,11 +31,11 @@ def main():
     m.reboil_ratio.set_value(1.3)
     # Fix to be total condenser
     m.partial_cond.deactivate()
-    m.total_cond.indicator_var.fix(1)
+    m.total_cond.indicator_var.fix(True)
     # Give initial values of the tray existence/absence
     for t in m.conditional_trays:
-        m.tray[t].indicator_var.set_value(1)
-        m.no_tray[t].indicator_var.set_value(0)
+        m.tray[t].indicator_var.set_value(True)
+        m.no_tray[t].indicator_var.set_value(False)
     # Run custom initialization routine
     initialize(m)
 
@@ -43,7 +43,7 @@ def main():
     m.BigM[None] = 100
 
     SolverFactory("gdpopt").solve(
-        m, tee=True, strategy="LOA", init_strategy="fix_disjuncts", mip_solver="glpk"
+        m, tee=True, algorithm="LOA", init_strategy="fix_disjuncts", mip_solver="glpk"
     )
     log_infeasible_constraints(m, tol=1e-3)
     display_column(m)

--- a/gdplib/hda/HDA_GDP_gdpopt.py
+++ b/gdplib/hda/HDA_GDP_gdpopt.py
@@ -3345,8 +3345,8 @@ def solve_with_gdpopt(m):
     res = opt.solve(
         m,
         tee=True,
-        strategy="LOA",
-        # strategy='GLOA',
+        algorithm="LOA",
+        # algorithm='GLOA',
         time_limit=3600,
         mip_solver="gams",
         mip_solver_args=dict(solver="cplex", warmstart=True),
@@ -3465,7 +3465,7 @@ def enumerate_solutions(m):
                             res = opt.solve(
                                 m,
                                 tee=False,
-                                strategy="LOA",
+                                algorithm="LOA",
                                 time_limit=3600,
                                 mip_solver="gams",
                                 mip_solver_args=dict(solver="gurobi", warmstart=True),

--- a/gdplib/kaibel/main_gdp.py
+++ b/gdplib/kaibel/main_gdp.py
@@ -90,20 +90,20 @@ def main():
     ## Initial values for the tray existence or absence
     for n_tray in m.candidate_trays_main:
         for sec in m.section_main:
-            m.tray_exists[sec, n_tray].indicator_var.set_value(1)
-            m.tray_absent[sec, n_tray].indicator_var.set_value(0)
+            m.tray_exists[sec, n_tray].indicator_var.set_value(True)
+            m.tray_absent[sec, n_tray].indicator_var.set_value(False)
     for n_tray in m.candidate_trays_feed:
-        m.tray_exists[2, n_tray].indicator_var.set_value(1)
-        m.tray_absent[2, n_tray].indicator_var.set_value(0)
+        m.tray_exists[2, n_tray].indicator_var.set_value(True)
+        m.tray_absent[2, n_tray].indicator_var.set_value(False)
     for n_tray in m.candidate_trays_product:
-        m.tray_exists[3, n_tray].indicator_var.set_value(1)
-        m.tray_absent[3, n_tray].indicator_var.set_value(0)
+        m.tray_exists[3, n_tray].indicator_var.set_value(True)
+        m.tray_absent[3, n_tray].indicator_var.set_value(False)
 
     intro_message(m)
 
     results = SolverFactory("gdpopt").solve(
         m,
-        strategy="LOA",
+        algorithm="LOA",
         tee=True,
         time_limit=3600,
         mip_solver="gams",

--- a/gdplib/med_term_purchasing/med_term_purchasing.py
+++ b/gdplib/med_term_purchasing/med_term_purchasing.py
@@ -1833,7 +1833,7 @@ def build_model():
             == model.Prices_Length[j, 2, t] * model.AmountPurchased_FD[j, t]
         )
         # only enforce these if we aren't in the last time period
-        if t < model.TimePeriods[-1]:
+        if t < model.TimePeriods.at(-1):
             disjunct.amount2 = Constraint(
                 expr=model.AmountPurchased_FD[j, t + 1] >= model.MinAmount_Length[j, 2]
             )
@@ -1874,7 +1874,7 @@ def build_model():
             == model.Prices_Length[j, 3, t] * model.AmountPurchased_FD[j, t]
         )
         # check we aren't in one of the last two time periods
-        if t < model.TimePeriods[-1]:
+        if t < model.TimePeriods.at(-1):
             disjunct.amount2 = Constraint(
                 expr=model.AmountPurchased_FD[j, t + 1] >= model.MinAmount_Length[j, 3]
             )
@@ -1882,7 +1882,7 @@ def build_model():
                 expr=model.Cost_FD[j, t + 1]
                 == model.Prices_Length[j, 3, t] * model.AmountPurchased_FD[j, t + 1]
             )
-        if t < model.TimePeriods[-2]:
+        if t < model.TimePeriods.at(-2):
             disjunct.amount3 = Constraint(
                 expr=model.AmountPurchased_FD[j, t + 2] >= model.MinAmount_Length[j, 3]
             )
@@ -1915,10 +1915,10 @@ def build_model():
         model = disjunct.model()
         disjunct.amount1 = Constraint(expr=model.AmountPurchased_FD[j, t] == 0)
         disjunct.cost1 = Constraint(expr=model.Cost_FD[j, t] == 0)
-        if t < model.TimePeriods[-1]:
+        if t < model.TimePeriods.at(-1):
             disjunct.amount2 = Constraint(expr=model.AmountPurchased_FD[j, t + 1] == 0)
             disjunct.cost2 = Constraint(expr=model.Cost_FD[j, t + 1] == 0)
-        if t < model.TimePeriods[-2]:
+        if t < model.TimePeriods.at(-2):
             disjunct.amount3 = Constraint(expr=model.AmountPurchased_FD[j, t + 2] == 0)
             disjunct.cost3 = Constraint(expr=model.Cost_FD[j, t + 2] == 0)
 

--- a/gdplib/methanol/methanol.py
+++ b/gdplib/methanol/methanol.py
@@ -1103,32 +1103,36 @@ def enumerate_solutions():
 
                     # fix the disjuncts
                     if feed_choice == 'cheap':
-                        m.cheap_feed_disjunct.indicator_var.fix(1)
-                        m.expensive_feed_disjunct.indicator_var.fix(0)
+                        m.cheap_feed_disjunct.indicator_var.fix(True)
+                        m.expensive_feed_disjunct.indicator_var.fix(False)
                     else:
-                        m.cheap_feed_disjunct.indicator_var.fix(0)
-                        m.expensive_feed_disjunct.indicator_var.fix(1)
+                        m.cheap_feed_disjunct.indicator_var.fix(False)
+                        m.expensive_feed_disjunct.indicator_var.fix(True)
 
                     if feed_compressor_choice == 'single_stage':
-                        m.single_stage_feed_compressor_disjunct.indicator_var.fix(1)
-                        m.two_stage_feed_compressor_disjunct.indicator_var.fix(0)
+                        m.single_stage_feed_compressor_disjunct.indicator_var.fix(True)
+                        m.two_stage_feed_compressor_disjunct.indicator_var.fix(False)
                     else:
-                        m.single_stage_feed_compressor_disjunct.indicator_var.fix(0)
-                        m.two_stage_feed_compressor_disjunct.indicator_var.fix(1)
+                        m.single_stage_feed_compressor_disjunct.indicator_var.fix(False)
+                        m.two_stage_feed_compressor_disjunct.indicator_var.fix(True)
 
                     if reactor_choice == 'cheap':
-                        m.cheap_reactor.indicator_var.fix(1)
-                        m.expensive_reactor.indicator_var.fix(0)
+                        m.cheap_reactor.indicator_var.fix(True)
+                        m.expensive_reactor.indicator_var.fix(False)
                     else:
-                        m.cheap_reactor.indicator_var.fix(0)
-                        m.expensive_reactor.indicator_var.fix(1)
+                        m.cheap_reactor.indicator_var.fix(False)
+                        m.expensive_reactor.indicator_var.fix(True)
 
                     if recycle_compressor_choice == 'single_stage':
-                        m.single_stage_recycle_compressor_disjunct.indicator_var.fix(1)
-                        m.two_stage_recycle_compressor_disjunct.indicator_var.fix(0)
+                        m.single_stage_recycle_compressor_disjunct.indicator_var.fix(
+                            True
+                        )
+                        m.two_stage_recycle_compressor_disjunct.indicator_var.fix(False)
                     else:
-                        m.single_stage_recycle_compressor_disjunct.indicator_var.fix(0)
-                        m.two_stage_recycle_compressor_disjunct.indicator_var.fix(1)
+                        m.single_stage_recycle_compressor_disjunct.indicator_var.fix(
+                            False
+                        )
+                        m.two_stage_recycle_compressor_disjunct.indicator_var.fix(True)
 
                     pe.TransformationFactory('gdp.fix_disjuncts').apply_to(m)
 

--- a/gdplib/modprodnet/model.py
+++ b/gdplib/modprodnet/model.py
@@ -237,7 +237,7 @@ if __name__ == "__main__":
         for case in cases:
             print(case)
             m = build_model(case)
-            m.conventional.indicator_var.fix(1)
+            m.conventional.indicator_var.fix(True)
             m.modular.deactivate()
             TransformationFactory("gdp.bigm").apply_to(m, bigM=7000)
             SolverFactory("gams").solve(m, solver="baron")
@@ -246,7 +246,7 @@ if __name__ == "__main__":
             del m
 
             m = build_model(case)
-            m.modular.indicator_var.fix(1)
+            m.modular.indicator_var.fix(True)
             m.conventional.deactivate()
             TransformationFactory("gdp.chull").apply_to(m)
             SolverFactory("gurobi").solve(m)

--- a/gdplib/small_batch/gdp_small_batch.py
+++ b/gdplib/small_batch/gdp_small_batch.py
@@ -398,7 +398,9 @@ def build_model():
     # Associate Boolean variables with with disjunction
     for k in m.k:
         for j in m.j:
-            m.Y[k, j].associate_binary_var(m.Y_exists[k, j].indicator_var)
+            m.Y[k, j].associate_binary_var(
+                m.Y_exists[k, j].indicator_var.get_associated_binary()
+            )
 
     # ____________________________
 

--- a/gdplib/syngas/syngas_adapted.py
+++ b/gdplib/syngas/syngas_adapted.py
@@ -1209,7 +1209,7 @@ if __name__ == "__main__":
     # )
     result = SolverFactory("gdpopt").solve(
         m,
-        strategy="LOA",
+        algorithm="LOA",
         tee=True,
         mip_solver="gams",
         nlp_solver="gams",

--- a/tests/test_pyomo_deprecations.py
+++ b/tests/test_pyomo_deprecations.py
@@ -1,0 +1,66 @@
+import logging
+
+import pyomo.environ as pyo
+
+DEPRECATION_PATTERNS = (
+    "implicitly casting",
+    "Implicit conversion of the Boolean indicator_var",
+    "Using __getitem__ to return a set value from its (ordered) position",
+    "associate_binary_var",
+)
+
+
+def _pyomo_warning_messages(caplog):
+    return "\n".join(
+        record.getMessage()
+        for record in caplog.records
+        if record.levelno >= logging.WARNING and record.name.startswith("pyomo")
+    )
+
+
+def _assert_no_known_pyomo_gdp_deprecations(caplog):
+    messages = _pyomo_warning_messages(caplog)
+    for pattern in DEPRECATION_PATTERNS:
+        assert pattern not in messages
+
+
+def test_gdp_col_build_uses_boolean_indicator_values(caplog):
+    import gdplib.gdp_col
+
+    caplog.set_level(logging.WARNING)
+
+    gdplib.gdp_col.build_model()
+
+    _assert_no_known_pyomo_gdp_deprecations(caplog)
+
+
+def test_med_term_purchasing_uses_ordered_set_at(caplog):
+    import gdplib.med_term_purchasing
+
+    caplog.set_level(logging.WARNING)
+
+    gdplib.med_term_purchasing.build_model()
+
+    _assert_no_known_pyomo_gdp_deprecations(caplog)
+
+
+def test_small_batch_bigm_avoids_boolean_indicator_conversion(caplog):
+    import gdplib.small_batch
+
+    caplog.set_level(logging.WARNING)
+    model = gdplib.small_batch.build_model()
+
+    pyo.TransformationFactory("gdp.bigm").apply_to(model)
+
+    _assert_no_known_pyomo_gdp_deprecations(caplog)
+
+
+def test_cstr_bigm_avoids_boolean_association_deprecations(caplog):
+    import gdplib.cstr
+
+    caplog.set_level(logging.WARNING)
+    model = gdplib.cstr.build_model()
+
+    pyo.TransformationFactory("gdp.bigm").apply_to(model)
+
+    _assert_no_known_pyomo_gdp_deprecations(caplog)


### PR DESCRIPTION
## Summary

- Replace numeric `0`/`1` assignments to Pyomo GDP indicator variables with Boolean `False`/`True`.
- Update direct GDPOpt solve calls from deprecated `strategy=` to `algorithm=`.
- Replace deprecated ordered Set positional access in `med_term_purchasing` with `Set.at(...)`.
- Associate the `small_batch` Boolean variable with the disjunct indicator's associated binary variable.
- Add warning-regression tests for the reported build and Big-M transform paths.

## Tests run

- `/home/bernalde/.pixi/bin/pixi run pytest tests/test_pyomo_deprecations.py -v --tb=short` -> 4 passed
- `/home/bernalde/.pixi/bin/pixi run pytest tests/test_module_imports.py -v --tb=short` -> 68 passed
- `/home/bernalde/.pixi/bin/pixi run test` -> 265 passed
- `/home/bernalde/.pixi/bin/pixi run lint` -> passed

## Notes about tests not run

- Did not run optional solver-backed optimization solves; the local validation covers model construction and GDP Big-M transform paths without requiring GAMS, IPOPT, or other external solvers.
- The documented lint task's second flake8 command uses `--exit-zero` and prints the repository's existing non-blocking style inventory.

Closes #55
