### PR TITLE
Fix methanol GDPopt solve options

### DIFF
--- a/gdplib/methanol/README.md
+++ b/gdplib/methanol/README.md
@@ -60,7 +60,10 @@ and 0.15 CH4. Feed 2 is 0.65 H2, 0.30 CO, and 0.05 CH4.
 
 ### Solution
 
-Best known objective value: 1583.00
+Best known objective value: -1793.4292381783 (optimal)
+
+The Pyomo objective minimizes negative profit for GDPopt compatibility.
+The corresponding maximum profit is 1793.4292381783 [$1000/yr].
 
 
 ### Size

--- a/gdplib/methanol/methanol.py
+++ b/gdplib/methanol/methanol.py
@@ -484,7 +484,8 @@ class MethanolModel(object):
         e -= self.cooling_cost * m.cooler_12.heat_duty
         e -= self.heating_cost * m.heater_14.heat_duty
         e -= self.heating_cost * m.heater_15.heat_duty
-        m.objective = pe.Objective(expr=-e)
+        m.profit = pe.Expression(expr=e, doc='Profit [$1000/yr]')
+        m.objective = pe.Objective(expr=-m.profit)
 
     def build_compressor(self, block, unit_number):
         """
@@ -1155,7 +1156,7 @@ def enumerate_solutions():
                             reactor_choice,
                             recycle_compressor_choice,
                             str(res.solver.termination_condition),
-                            str(-pe.value(m.objective)),
+                            str(pe.value(m.profit)),
                         )
                     )
     time_elapsed = time.time() - since
@@ -1187,35 +1188,77 @@ def build_model():
     return m
 
 
-def solve_with_gdp_opt():
+def solve_with_gdp_opt(
+    algorithm='LOA',
+    mip_solver='gams',
+    nlp_solver='gams',
+    tee=True,
+    mip_solver_args=None,
+    nlp_solver_args=None,
+    return_results=False,
+    print_results=True,
+    **solve_options,
+):
     """
-    Solve the methanol production model using LOA (logic-based outer approximation) with GDPopt solver.
+    Solve the methanol production model with GDPopt.
+
+    Parameters
+    ----------
+    algorithm : str
+        GDPopt algorithm name. Defaults to ``'LOA'``.
+    mip_solver : str
+        Solver used for GDPopt MIP master problems.
+    nlp_solver : str
+        Solver used for GDPopt NLP subproblems.
+    tee : bool
+        Stream GDPopt output during the solve.
+    mip_solver_args : dict, optional
+        Additional keyword arguments for the MIP solver.
+    nlp_solver_args : dict, optional
+        Additional keyword arguments for the NLP solver. For example,
+        ``{'solver': 'baron'}`` selects GAMS/BARON for NLP subproblems.
+    return_results : bool
+        If True, return ``(model, results)``. The default preserves the
+        historical return value of only the model.
+    print_results : bool
+        Print active disjunct names and the solver result object after solving.
+    **solve_options
+        Additional keyword arguments passed through to ``GDPopt.solve()``.
 
     Returns
     -------
     m : Pyomo.ConcreteModel
         The Pyomo model.
+    res : SolverResults, optional
+        GDPopt solve results when ``return_results`` is True.
     """
 
-    m = MethanolModel().model
-    for _d in m.component_data_objects(
-        gdp.Disjunct, descend_into=True, active=True, sort=True
-    ):
-        _d.BigM = pe.Suffix()
-        for _c in _d.component_data_objects(
-            pe.Constraint, descend_into=True, active=True, sort=True
-        ):
-            lb, ub = compute_bounds_on_expr(_c.body)
-            _d.BigM[_c] = max(abs(lb), abs(ub))
+    m = build_model()
     opt = pe.SolverFactory('gdpopt')
-    res = opt.solve(m, algorithm='LOA', mip_solver='gams', nlp_solver='gams', tee=True)
-    for d in m.component_data_objects(
-        ctype=gdp.Disjunct, active=True, sort=True, descend_into=True
-    ):
-        if d.indicator_var.value == 1:
-            print(d.name)
-    print(res)
+    solve_kwargs = {
+        'algorithm': algorithm,
+        'mip_solver': mip_solver,
+        'nlp_solver': nlp_solver,
+        'tee': tee,
+    }
+    if mip_solver_args is not None:
+        solve_kwargs['mip_solver_args'] = mip_solver_args
+    if nlp_solver_args is not None:
+        solve_kwargs['nlp_solver_args'] = nlp_solver_args
+    solve_kwargs.update(solve_options)
 
+    res = opt.solve(m, **solve_kwargs)
+
+    if print_results:
+        for d in m.component_data_objects(
+            ctype=gdp.Disjunct, active=True, sort=True, descend_into=True
+        ):
+            if d.indicator_var.value is True:
+                print(d.name)
+        print(res)
+
+    if return_results:
+        return m, res
     return m
 
 

--- a/tests/test_methanol.py
+++ b/tests/test_methanol.py
@@ -1,0 +1,71 @@
+from types import SimpleNamespace
+
+from pyomo.gdp import Disjunct
+
+import gdplib.methanol.methanol as methanol
+
+
+class _FakeGDPopt:
+    def __init__(self, captured):
+        self._captured = captured
+
+    def solve(self, model, **kwargs):
+        self._captured['model'] = model
+        self._captured['kwargs'] = kwargs
+        return SimpleNamespace(solver=SimpleNamespace(termination_condition='optimal'))
+
+
+def _patch_gdpopt(monkeypatch):
+    captured = {}
+
+    def fake_solver_factory(name):
+        captured['solver_name'] = name
+        return _FakeGDPopt(captured)
+
+    monkeypatch.setattr(methanol.pe, 'SolverFactory', fake_solver_factory)
+    return captured
+
+
+def test_solve_with_gdp_opt_passes_solver_options(monkeypatch):
+    captured = _patch_gdpopt(monkeypatch)
+
+    model, results = methanol.solve_with_gdp_opt(
+        tee=False,
+        mip_solver_args={'solver': 'gurobi'},
+        nlp_solver_args={'solver': 'baron'},
+        time_limit=60,
+        return_results=True,
+        print_results=False,
+    )
+
+    assert captured['solver_name'] == 'gdpopt'
+    assert captured['model'] is model
+    assert captured['kwargs'] == {
+        'algorithm': 'LOA',
+        'mip_solver': 'gams',
+        'nlp_solver': 'gams',
+        'tee': False,
+        'mip_solver_args': {'solver': 'gurobi'},
+        'nlp_solver_args': {'solver': 'baron'},
+        'time_limit': 60,
+    }
+    assert results.solver.termination_condition == 'optimal'
+
+
+def test_solve_with_gdp_opt_preserves_model_return(monkeypatch):
+    captured = _patch_gdpopt(monkeypatch)
+
+    model = methanol.solve_with_gdp_opt(tee=False, print_results=False)
+
+    assert model is captured['model']
+    assert 'mip_solver_args' not in captured['kwargs']
+    assert 'nlp_solver_args' not in captured['kwargs']
+    first_disjunct = next(model.component_data_objects(Disjunct, active=True))
+    assert len(first_disjunct.BigM) > 0
+
+
+def test_build_model_exposes_profit_and_minimizes_negative_profit():
+    model = methanol.build_model()
+
+    assert model.objective.sense == methanol.pe.minimize
+    assert hasattr(model, 'profit')


### PR DESCRIPTION
## Summary

- Refactor the methanol GDPopt solve helper to reuse `build_model()` so the solve path uses the same Big-M setup as normal construction.
- Add configurable GDPopt solver arguments, including `nlp_solver_args`, so the GAMS/BARON NLP-subproblem path discussed in issue 42 can be selected without editing source code.
- Preserve the historical default return value while allowing callers/tests to request `(model, results)`.
- Expose a positive `m.profit` expression, keep the GDPopt objective as minimized negative profit, and document the objective/profit sign convention.
- Update the methanol README with the locally verified optimal solver objective and corresponding maximum profit.
- Add solver-free regression tests for the GDPopt helper's option forwarding, return behavior, and objective sign convention.

## Tests run

- `/home/bernalde/.pixi/bin/pixi run pytest tests/test_methanol.py -v --tb=short`  
  Result: `3 passed in 1.77s`.
- `/home/bernalde/.pixi/bin/pixi run pytest tests/test_module_imports.py -v --tb=short`  
  Result: `68 passed in 6.59s`.
- `/home/bernalde/.pixi/bin/pixi run python - <<'PY' ... PY` with `solve_with_gdp_opt(tee=False, print_results=False, return_results=True)`  
  Result: `optimal`, objective `-1793.4292381783353`, profit `1793.4292381783353`, active disjuncts `['cheap_reactor', 'expensive_feed_disjunct', 'single_stage_recycle_compressor_disjunct', 'two_stage_feed_compressor_disjunct']`.
- `/home/bernalde/.pixi/bin/pixi run lint-black`  
  Result: `79 files would be left unchanged`.
- `/home/bernalde/.pixi/bin/pixi run lint-flake8-critical`  
  Result: `0`.
- `/home/bernalde/.pixi/bin/pixi run lint-typos`  
  Result: passed.
- `/home/bernalde/.pixi/bin/pixi run test`  
  Result: `268 passed in 23.00s`.

## Notes

- No local test was skipped intentionally.
- The solver-backed methanol verification used the local Pixi environment with GDPopt and GAMS available; default construction and committed tests still do not require optional solver stacks.
- IDAES uses an explicit maximization objective for its rigorous methanol flowsheet. This GDP superstructure keeps the existing minimized negative-profit objective for the verified GDPopt LOA solve path while exposing `m.profit` for the positive economic value.

Closes #42
