### PR TITLE
Add PyPI release workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,93 @@
+name: Publish
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: build-distributions
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out source
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install build tools
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install build twine
+
+      - name: Build distributions
+        run: python -m build
+
+      - name: Check distributions
+        run: python -m twine check dist/*
+
+      - name: Upload distributions
+        uses: actions/upload-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/
+          if-no-files-found: error
+
+  test-wheel:
+    name: test-wheel-python-${{ matrix.python-version }}
+    needs: build
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.11", "3.12"]
+
+    steps:
+      - name: Download distributions
+        uses: actions/download-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install wheel artifact
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install dist/*.whl
+
+      - name: Import package
+        run: python -c "import gdplib; print('GDPlib import successful')"
+
+  publish:
+    name: publish-to-pypi
+    needs: [build, test-wheel]
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/project/gdplib/
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Download distributions
+        uses: actions/download-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist
+
+      - name: Publish distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist/

--- a/README.md
+++ b/README.md
@@ -59,6 +59,42 @@ pixi run test
 pixi run lint
 ```
 
+### PyPI Release Workflow
+
+PyPI releases are published by
+[`.github/workflows/publish.yml`](./.github/workflows/publish.yml) when a
+GitHub Release is published. Package versions come from git tags through
+`setuptools_scm`, so create the release from the version tag intended for PyPI.
+The build backend remains `setuptools.build_meta` as configured in
+`pyproject.toml`, and package maintainer metadata remains defined there.
+
+The publish workflow checks out full git history, builds both the sdist and
+wheel with `python -m build`, validates them with
+`python -m twine check dist/*`, installs the wheel on Python 3.10, 3.11, and
+3.12, and then publishes with PyPI Trusted Publishing through the protected
+`pypi` GitHub environment. The PyPI project must have a trusted publisher entry
+for this repository, the `publish.yml` workflow, and the `pypi` environment
+before publishing the first release.
+
+Before publishing a GitHub Release, run the normal local checks:
+
+```bash
+pixi run test
+pixi run lint
+```
+
+If local artifact validation is needed, install the PyPA build tools in the
+active environment and run:
+
+```bash
+python -m build
+python -m twine check dist/*
+```
+
+The committed Pixi environment remains `linux-64` only. Do not add Pixi
+platforms for release work unless the lock file is regenerated and the selected
+platforms are verified according to the development policy above.
+
 ### Benchmark Campaigns
 
 The benchmark runner can preflight the PR #58 benchmark campaign before starting

--- a/tests/test_release_workflow.py
+++ b/tests/test_release_workflow.py
@@ -1,0 +1,43 @@
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+PUBLISH_WORKFLOW = ROOT / ".github" / "workflows" / "publish.yml"
+README = ROOT / "README.md"
+
+
+def test_publish_workflow_builds_and_validates_before_publishing():
+    workflow = PUBLISH_WORKFLOW.read_text()
+
+    build_index = workflow.index("python -m build")
+    check_index = workflow.index("python -m twine check dist/*")
+    install_index = workflow.index("python -m pip install dist/*.whl")
+    publish_index = workflow.index("pypa/gh-action-pypi-publish@release/v1")
+
+    assert build_index < check_index < install_index < publish_index
+    assert "fetch-depth: 0" in workflow
+    assert "python-package-distributions" in workflow
+    assert "id-token: write" in workflow
+    assert "name: pypi" in workflow
+
+
+def test_publish_workflow_uses_release_trigger_and_supported_python_matrix():
+    workflow = PUBLISH_WORKFLOW.read_text()
+
+    assert "\non:\n  release:\n    types: [published]\n" in workflow
+    assert 'python-version: ["3.10", "3.11", "3.12"]' in workflow
+
+
+def test_readme_documents_release_process_and_pixi_policy():
+    readme = README.read_text()
+
+    for phrase in [
+        ".github/workflows/publish.yml",
+        "setuptools.build_meta",
+        "setuptools_scm",
+        "PyPI Trusted Publishing",
+        "pixi run test",
+        "pixi run lint",
+        "python -m twine check dist/*",
+        "linux-64",
+    ]:
+        assert phrase in readme


### PR DESCRIPTION
## Summary

- Add a GitHub Actions publish workflow for PyPI releases triggered by published GitHub Releases.
- Build and validate sdist/wheel artifacts before publishing, then smoke-test wheel installation on Python 3.10, 3.11, and 3.12.
- Document the release process, `setuptools_scm` version source, `setuptools.build_meta` backend, PyPI Trusted Publishing setup, and the current Linux-only Pixi policy.
- Add static regression tests for the workflow and release documentation.

## Tests run

- `/home/bernalde/.pixi/bin/pixi run pytest tests/test_release_workflow.py -v --tb=short` - passed, 3 tests.
- `/home/bernalde/.pixi/bin/pixi run test` - passed, 271 tests.
- `/home/bernalde/.pixi/bin/pixi run lint` - passed. The broad flake8 report still emits existing non-gating style findings because that repository task uses `--exit-zero`.
- `/home/bernalde/repos/gdplib/.pixi/envs/default/bin/python -m build` from a clean temporary copy - passed, built sdist and wheel. Existing setuptools metadata deprecation warnings were emitted.
- `/home/bernalde/repos/gdplib/.pixi/envs/default/bin/python -m twine check dist/*` from the temporary build directory - passed for both artifacts.
- `/tmp/gdplib-wheel-smoke/bin/python -m pip install /tmp/gdplib-final-build.MfIeaq/dist/*.whl` - passed.
- `/tmp/gdplib-wheel-smoke/bin/python -c "import gdplib; print('GDPlib import successful')"` - passed.

## Notes

- Publishing itself was not run locally because it requires a published GitHub Release and PyPI Trusted Publishing configuration for the `pypi` environment.
- Follow-up issue #104 was considered; this PR documents the release workflow and keeps Pixi platform support at the existing `linux-64` scope.
- Existing packaging warnings about `setup.cfg` `description-file`, `project.license`, and license classifiers remain follow-up cleanup.

Closes #51
Refs #104
