### PR TITLE
Document release workflow lessons

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -245,3 +245,26 @@ These instructions apply to the whole repository.
 - Packaging tests can regenerate `gdplib/_version.py` and the editable package
   entry in `pixi.lock`. Do not commit that churn unless the task is explicitly
   about versioning, release metadata, or regenerating the Pixi lock.
+- PyPI publishing is intentionally release-driven. Keep publish workflows tied
+  to published GitHub Releases or another explicit maintainer release action,
+  not ordinary pushes or pull requests. Publishing should use PyPI Trusted
+  Publishing through the protected `pypi` environment unless maintainers choose
+  and document another credential path.
+- Release workflow changes should build and validate real artifacts before any
+  publish step. Include `python -m build`, `python -m twine check dist/*`, and
+  a wheel install/import smoke test across the supported Python versions when
+  practical. Keep these checks in CI or document why a local-only check is the
+  best available evidence.
+- `setuptools_scm` needs intact git metadata to infer release versions. CI
+  builds should check out full history, and local artifact checks should run
+  from a real git checkout or set an explicit pretend version only when the
+  purpose is isolated packaging validation. Do not rely on source copies without
+  `.git` metadata as release evidence.
+- Pixi is the preferred Linux development environment, not a runtime
+  requirement for PyPI users. A release should remain installable with standard
+  pip tooling from the wheel or sdist, and package metadata should not depend on
+  Pixi-only files.
+- Treat packaging deprecation warnings from `setuptools`, `setuptools_scm`, or
+  PyPA tools as useful follow-up work. Keep warning cleanup in a focused
+  metadata PR unless the warning causes the release build, artifact validation,
+  or installation smoke test to fail.


### PR DESCRIPTION
## Summary

- Add release-workflow lessons to `AGENTS.md` after merging the PyPI publish workflow.
- Document that PyPI publishing should stay tied to explicit release actions and PyPI Trusted Publishing.
- Capture validation expectations for release workflow changes: real artifact builds, `twine check`, wheel install/import smoke tests, and full git metadata for `setuptools_scm`.
- Clarify that Pixi is a development environment, not a runtime requirement for pip users, and that PyPA metadata warnings should be handled in focused follow-up PRs unless they break release validation.

## Tests run

- `git diff --check -- AGENTS.md` - passed.
- `/home/bernalde/.pixi/bin/pixi run lint-typos` - passed.
- `/home/bernalde/.pixi/bin/pixi run test` - passed, 271 tests.
- `/home/bernalde/.pixi/bin/pixi run lint` - exited 0. The broad flake8 `--exit-zero` report still lists existing repository style findings.

## Notes

- This is a documentation-only update to `AGENTS.md`.
- Existing local edits to `gdplib/_version.py`, `pixi.lock`, and `pixi.toml` were intentionally left unstaged and are not part of this PR.
