### PR TITLE
Document release and Pixi support policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,21 @@ pixi run test
 pixi run lint
 ```
 
+The committed Pixi support surface is `linux-64` only because that is the
+platform the maintainers can verify with `pixi install`, `pixi run test`, and
+`pixi run lint`. The `pixi.lock` file should cover exactly the platforms listed
+in `pixi.toml`; do not commit lock-file changes for `osx-64`, `osx-arm64`,
+`win-64`, or another platform unless that platform has been added deliberately
+and verified with the same commands. macOS and Windows users should use the pip
+workflow unless a PR explicitly adds and verifies Pixi support for those
+platforms.
+
+The default Pixi environment intentionally excludes optional external
+optimization solver stacks and licensed solver bindings. Keep GAMS, BARON,
+IPOPT, Gurobi, HiGHS, and similar tools in optional local environments,
+benchmark profiles, or documentation unless they become required for default
+imports and tests.
+
 ### PyPI Release Workflow
 
 PyPI releases are published by

--- a/tests/test_release_workflow.py
+++ b/tests/test_release_workflow.py
@@ -3,6 +3,7 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 PUBLISH_WORKFLOW = ROOT / ".github" / "workflows" / "publish.yml"
 README = ROOT / "README.md"
+PIXI = ROOT / "pixi.toml"
 
 
 def test_publish_workflow_builds_and_validates_before_publishing():
@@ -39,5 +40,21 @@ def test_readme_documents_release_process_and_pixi_policy():
         "pixi run lint",
         "python -m twine check dist/*",
         "linux-64",
+        "pixi.lock",
+        "pixi.toml",
+        "macOS and Windows users",
+        "pip workflow",
+        "default Pixi environment intentionally excludes optional external",
     ]:
         assert phrase in readme
+
+
+def test_pixi_manifest_matches_documented_platform_policy():
+    pixi = PIXI.read_text()
+    readme = README.read_text()
+
+    assert 'platforms = ["linux-64"]' in pixi
+    assert "The committed Pixi support surface is `linux-64` only" in readme
+    assert "pixi install" in readme
+    assert "pixi run test" in readme
+    assert "pixi run lint" in readme


### PR DESCRIPTION
## Summary

- Documents the selected Pixi support surface as `linux-64` only and ties `pixi.lock` coverage to the platforms listed in `pixi.toml`.
- Clarifies that macOS and Windows users should use the pip workflow unless Pixi support is deliberately added and verified.
- Clarifies that optional external solver stacks and licensed solver bindings stay out of the default Pixi environment unless needed for default imports/tests.
- Extends release workflow tests to assert the documented release and Pixi platform policy.

## Tests run

- `/home/bernalde/.pixi/bin/pixi run pytest tests/test_release_workflow.py -v --tb=short` - passed, 4 passed.
- `/home/bernalde/.pixi/bin/pixi run test` - passed, 272 passed.
- `/home/bernalde/.pixi/bin/pixi run lint` - passed. Black, critical flake8, non-fatal broad flake8 (`--exit-zero`), and typos completed; the broad flake8 pass reported existing style findings but exited 0 as configured.
- `git diff --check -- README.md tests/test_release_workflow.py` - passed.

## Notes

- No Pixi platform or lock-file changes are included; the selected committed Pixi platform remains `linux-64`.
- Unrelated local edits to `gdplib/_version.py`, `pixi.lock`, and `pixi.toml` were not staged or committed.

Closes #104
