### PR TITLE
[codex] Document Pixi release policy lessons

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,12 +31,17 @@ These instructions apply to the whole repository.
   unavailable and the fallback is called out explicitly.
 - If `pixi` is not on `PATH`, check whether a local Pixi binary exists (for
   example `$HOME/.pixi/bin/pixi`) before falling back to the pip workflow.
+- The committed Pixi support surface is exactly the platform list in
+  `pixi.toml` and the matching entries in `pixi.lock`; it is currently
+  `linux-64`. Keep README, `pixi.toml`, and `pixi.lock` aligned when changing
+  that policy.
 - On macOS or Windows, use the pip workflow below unless the task explicitly
-  expands Pixi platform support and regenerates `pixi.lock`.
+  expands Pixi platform support.
 - Do not add Pixi platforms casually. Adding `osx-64`, `osx-arm64`, `win-64`,
-  or another platform should also regenerate `pixi.lock` and verify
-  `pixi install`, `pixi run test`, and `pixi run lint` on that platform, or be
-  tracked as follow-up work.
+  or another platform must also regenerate `pixi.lock` and verify
+  `pixi install`, `pixi run test`, and `pixi run lint` on that platform before
+  committing manifest or lock-file changes. If the platform cannot be verified,
+  leave the manifest and lock unchanged and document the work as follow-up.
 - The legacy pip workflow is still supported:
   ```bash
   pip install -r requirements.txt
@@ -63,6 +68,9 @@ These instructions apply to the whole repository.
   `build_model()` and turn it into a skip.
 - For line-ending-heavy PRs, inspect `git diff --ignore-cr-at-eol`, still run
   `git diff --check`, and avoid unrelated normalization.
+- For GitHub issue or PR inspection through `gh`, prefer explicit `--json`
+  field lists when default views request deprecated GraphQL fields such as
+  Projects Classic `projectCards`.
 - Match CI formatting and linting:
   ```bash
   black -S -C --target-version py310 --check --diff .
@@ -241,10 +249,17 @@ These instructions apply to the whole repository.
 
 - Runtime dependencies belong in `pyproject.toml`, `setup.py`, and `requirements.txt`.
 - Development-only tools belong in `requirements-dev.txt` and the Pixi environment.
-- Add solver packages only to optional environments or documentation unless they are required for default imports and tests.
+- Keep optional external solver stacks and licensed solver bindings out of the
+  default Pixi environment unless they are required for default imports and
+  tests. Put GAMS, BARON, IPOPT, Gurobi, HiGHS, and similar tools in optional
+  local environments, optional Pixi features, benchmark profiles, or
+  documentation.
 - Packaging tests can regenerate `gdplib/_version.py` and the editable package
   entry in `pixi.lock`. Do not commit that churn unless the task is explicitly
   about versioning, release metadata, or regenerating the Pixi lock.
+- When changing release workflow or Pixi support policy docs, update
+  `tests/test_release_workflow.py` so README, `publish.yml`, `pixi.toml`, and
+  AGENTS.md stay aligned.
 - PyPI publishing is intentionally release-driven. Keep publish workflows tied
   to published GitHub Releases or another explicit maintainer release action,
   not ordinary pushes or pull requests. Publishing should use PyPI Trusted

--- a/tests/test_release_workflow.py
+++ b/tests/test_release_workflow.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
+AGENTS = ROOT / "AGENTS.md"
 PUBLISH_WORKFLOW = ROOT / ".github" / "workflows" / "publish.yml"
 README = ROOT / "README.md"
 PIXI = ROOT / "pixi.toml"
@@ -58,3 +59,17 @@ def test_pixi_manifest_matches_documented_platform_policy():
     assert "pixi install" in readme
     assert "pixi run test" in readme
     assert "pixi run lint" in readme
+
+
+def test_agents_documents_release_and_pixi_policy_lessons():
+    agents = AGENTS.read_text()
+
+    for phrase in [
+        "The committed Pixi support surface is exactly the platform list",
+        "`pixi.toml` and the matching entries in `pixi.lock`",
+        "leave the manifest and lock unchanged",
+        "deprecated GraphQL fields",
+        "Keep optional external solver stacks and licensed solver bindings out",
+        "tests/test_release_workflow.py",
+    ]:
+        assert phrase in agents


### PR DESCRIPTION
## Summary

- Tightens AGENTS.md guidance from the PR #120 follow-up: the committed Pixi support surface is the `pixi.toml` platform list plus matching `pixi.lock` entries, currently `linux-64`.
- Clarifies that unsupported Pixi platforms should not add manifest or lock churn unless they are deliberately added and verified with `pixi install`, `pixi run test`, and `pixi run lint`.
- Clarifies that optional external solver stacks and licensed solver bindings should stay out of the default Pixi environment unless they become required for default imports/tests.
- Records the `gh` lesson from PR #120: use explicit `--json` field lists when default issue/PR views hit deprecated GraphQL fields.
- Adds a release-policy test that checks AGENTS.md keeps these lessons.

## Validation

- `/home/bernalde/.pixi/bin/pixi run pytest tests/test_release_workflow.py -v --tb=short` - passed, 5 passed.
- `/home/bernalde/.pixi/bin/pixi run test` - passed, 273 passed.
- `/home/bernalde/.pixi/bin/pixi run lint` - passed. Black, critical flake8, broad flake8 with `--exit-zero`, and typos completed; broad flake8 reported existing non-fatal findings.
- `git diff --check -- AGENTS.md tests/test_release_workflow.py` - passed.

## Notes

- Unrelated local edits to `gdplib/_version.py`, `pixi.lock`, and `pixi.toml` were not staged or committed.
