### PR TITLE
Document GDP discrete-semantics test lesson

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -240,6 +240,12 @@ These instructions apply to the whole repository.
   representative initialized data and smoke-test supported transformations such
   as `gdp.bigm` and `gdp.hull`. Keep this separate from solver-backed
   optimality evidence.
+- For ordered-location superstructures or activation-prefix rewrites, test the
+  discrete semantics directly on a small representative instance. Enumerate the
+  relevant binary activation/location choices and assert the intended valid
+  combinations, including any derived feed, recycle, or terminal-location
+  expressions. Component-type checks and transformation smoke tests are useful
+  but are not enough to protect the modeling semantics.
 - For scalable model changes, verify the documented/default instance and at
   least one larger instance when practical. If semantics should be unchanged,
   compare transformed model counts or generated algebraic representations where


### PR DESCRIPTION
## Summary

- Adds an AGENTS.md lesson from the CSTR GLOA fix: ordered-location and activation-prefix rewrites need direct discrete-semantics tests.
- Calls out that component-type checks and GDP transformation smoke tests are useful but insufficient on their own for modeling semantics.

## Tests

- `git diff --check` -> passed
- `/home/bernalde/.pixi/bin/pixi run pytest tests/test_release_workflow.py::test_agents_documents_release_and_pixi_policy_lessons -v --tb=short` -> passed

## Notes

- Documentation-only change.
- Existing unstaged local changes in `gdplib/_version.py`, `pixi.toml`, and `pixi.lock` were not touched or included.
