### PR TITLE
Fix gdp_col hull reformulation

### DIFF
--- a/gdplib/gdp_col/column.py
+++ b/gdplib/gdp_col/column.py
@@ -6,12 +6,13 @@ from pyomo.environ import (
     Block,
     ConcreteModel,
     Constraint,
-    log,
+    exp,
     minimize,
     NonNegativeReals,
     Objective,
     RangeSet,
     Set,
+    value,
     Var,
 )
 from pyomo.gdp import Disjunct, Disjunction
@@ -389,13 +390,11 @@ def build_column(min_trays, max_trays, xD, xB):
     m.H_L_spec_feed = Var(
         m.comps,
         doc="Component liquid molar enthalpy in feed [kJ/mol]",
-        initialize=0,
         bounds=(0.1, 16),
     )
     m.H_V_spec_feed = Var(
         m.comps,
         doc="Component vapor molar enthalpy in feed [kJ/mol]",
-        initialize=0,
         bounds=(30, 16 + 40),
     )
     m.Qb = Var(
@@ -431,6 +430,9 @@ def build_column(min_trays, max_trays, xD, xB):
     m.dH_vap = {"benzene": 33.770e3, "toluene": 38.262e3}  # J/mol
 
     _build_column_heat_relations(m)
+    for c in m.comps:
+        m.H_L_spec_feed[c].set_value(value(m.feed_liq_enthalpy_expr[c]))
+        m.H_V_spec_feed[c].set_value(value(m.feed_vap_enthalpy_expr[c]))
 
     @m.Constraint()
     def distillate_req(m):
@@ -1096,12 +1098,12 @@ def _build_tray_phase_equilibrium(m, t, tray):
         Returns
         -------
         Pyomo.Constraint
-            Antoine's equation for the vapor pressure of each component in a tray is calculated as the logarithm of the vapor pressure minus the logarithm of the critical pressure times one minus the fraction of critical temperature. The equation is equal to the sum of the Antoine coefficients times the fraction of critical temperature raised to different powers.
+            Antoine's equation for the vapor pressure of each component in a tray.
         """
         k = m.pvap_const[c]
         x = m.Pvap_X[c, t]
-        return (log(m.Pvap[c, t]) - log(k["Pc"])) * (1 - x) == (
-            k["A"] * x + k["B"] * x**1.5 + k["C"] * x**3 + k["D"] * x**6
+        return m.Pvap[c, t] == k["Pc"] * exp(
+            (k["A"] * x + k["B"] * x**1.5 + k["C"] * x**3 + k["D"] * x**6) / (1 - x)
         )
 
     @tray.Constraint(m.comps)

--- a/tests/test_gdp_col.py
+++ b/tests/test_gdp_col.py
@@ -1,0 +1,42 @@
+"""Regression tests for the gdp_col distillation column model."""
+
+import logging
+
+import pyomo.environ as pyo
+from pyomo.gdp import Disjunction
+
+import gdplib.gdp_col
+
+
+def _pyomo_warning_messages(caplog):
+    return "\n".join(
+        record.getMessage()
+        for record in caplog.records
+        if record.levelno >= logging.WARNING and record.name.startswith("pyomo")
+    )
+
+
+def test_gdp_col_build_initializes_feed_enthalpy_within_bounds(caplog):
+    caplog.set_level(logging.WARNING)
+
+    model = gdplib.gdp_col.build_model()
+
+    for var in (model.H_L_spec_feed, model.H_V_spec_feed):
+        for component in model.comps:
+            value = pyo.value(var[component])
+            lower, upper = var[component].bounds
+            assert lower <= value <= upper
+
+    messages = _pyomo_warning_messages(caplog)
+    assert "H_L_spec_feed" not in messages
+    assert "H_V_spec_feed" not in messages
+
+
+def test_gdp_col_reformulates_with_hull():
+    model = gdplib.gdp_col.build_model()
+
+    assert any(model.component_data_objects(Disjunction, active=True))
+
+    pyo.TransformationFactory("gdp.hull").apply_to(model)
+
+    assert not any(model.component_data_objects(Disjunction, active=True))

--- a/tests/test_pyomo_deprecations.py
+++ b/tests/test_pyomo_deprecations.py
@@ -1,6 +1,7 @@
 import logging
 
 import pyomo.environ as pyo
+from pyomo.gdp import Disjunction
 
 DEPRECATION_PATTERNS = (
     "implicitly casting",
@@ -32,6 +33,36 @@ def test_gdp_col_build_uses_boolean_indicator_values(caplog):
     gdplib.gdp_col.build_model()
 
     _assert_no_known_pyomo_gdp_deprecations(caplog)
+
+
+def test_gdp_col_build_initializes_feed_enthalpy_within_bounds(caplog):
+    import gdplib.gdp_col
+
+    caplog.set_level(logging.WARNING)
+
+    model = gdplib.gdp_col.build_model()
+
+    for var in (model.H_L_spec_feed, model.H_V_spec_feed):
+        for component in model.comps:
+            value = pyo.value(var[component])
+            lower, upper = var[component].bounds
+            assert lower <= value <= upper
+
+    messages = _pyomo_warning_messages(caplog)
+    assert "H_L_spec_feed" not in messages
+    assert "H_V_spec_feed" not in messages
+
+
+def test_gdp_col_reformulates_with_hull():
+    import gdplib.gdp_col
+
+    model = gdplib.gdp_col.build_model()
+
+    assert any(model.component_data_objects(Disjunction, active=True))
+
+    pyo.TransformationFactory("gdp.hull").apply_to(model)
+
+    assert not any(model.component_data_objects(Disjunction, active=True))
 
 
 def test_med_term_purchasing_uses_ordered_set_at(caplog):

--- a/tests/test_pyomo_deprecations.py
+++ b/tests/test_pyomo_deprecations.py
@@ -1,7 +1,6 @@
 import logging
 
 import pyomo.environ as pyo
-from pyomo.gdp import Disjunction
 
 DEPRECATION_PATTERNS = (
     "implicitly casting",
@@ -33,36 +32,6 @@ def test_gdp_col_build_uses_boolean_indicator_values(caplog):
     gdplib.gdp_col.build_model()
 
     _assert_no_known_pyomo_gdp_deprecations(caplog)
-
-
-def test_gdp_col_build_initializes_feed_enthalpy_within_bounds(caplog):
-    import gdplib.gdp_col
-
-    caplog.set_level(logging.WARNING)
-
-    model = gdplib.gdp_col.build_model()
-
-    for var in (model.H_L_spec_feed, model.H_V_spec_feed):
-        for component in model.comps:
-            value = pyo.value(var[component])
-            lower, upper = var[component].bounds
-            assert lower <= value <= upper
-
-    messages = _pyomo_warning_messages(caplog)
-    assert "H_L_spec_feed" not in messages
-    assert "H_V_spec_feed" not in messages
-
-
-def test_gdp_col_reformulates_with_hull():
-    import gdplib.gdp_col
-
-    model = gdplib.gdp_col.build_model()
-
-    assert any(model.component_data_objects(Disjunction, active=True))
-
-    pyo.TransformationFactory("gdp.hull").apply_to(model)
-
-    assert not any(model.component_data_objects(Disjunction, active=True))
 
 
 def test_med_term_purchasing_uses_ordered_set_at(caplog):


### PR DESCRIPTION
## Summary

- Initialize `gdp_col` feed liquid and vapor enthalpy variables from the existing feed enthalpy expressions so construction no longer emits out-of-bounds Pyomo W1002 warnings.
- Rewrite the active-tray Antoine vapor-pressure relation in algebraically equivalent exponential form so Pyomo's default `gdp.hull` transformation no longer evaluates `log(0)` in the hull perspective.
- Add focused regression coverage for feed enthalpy initialization and solver-free `gdp.hull` reformulation.
- Add an optional Pixi `gurobi` environment for direct `gurobipy`/Pyomo Gurobi checks without making licensed solver bindings part of the default environment.

## Tests run

- `/home/bernalde/.pixi/bin/pixi run pytest tests/test_pyomo_deprecations.py -v --tb=short` -> 6 passed.
- `/home/bernalde/.pixi/bin/pixi run pytest tests/test_module_imports.py -v --tb=short` -> 68 passed.
- `/home/bernalde/.pixi/bin/pixi run test` -> 279 passed, 1 skipped.
- `/home/bernalde/.pixi/bin/pixi run lint` -> passed with exit code 0. The configured non-fatal flake8 inventory still reports existing repository style findings under `--exit-zero`.
- `/home/bernalde/.pixi/bin/pixi run gdplib-benchmark warnings --instances gdp_col --strategies gdp.hull --mode transform --no-check-solvers --run-id issue66_hull_warning --metadata-dir /tmp/gdplib-issue66-warning-metadata` -> 0 warning events, 0 unique warning rows, 0 deprecation candidate events, 0 capture errors.
- `/home/bernalde/.pixi/bin/pixi install -e gurobi` -> installed the optional Gurobi Pixi environment.
- `/home/bernalde/.pixi/bin/pixi run -e gurobi python -c "import gurobipy as gp; from pyomo.environ import SolverFactory; print(gp.gurobi.version()); print(SolverFactory('gurobi_direct').available(False))"` -> `(12, 0, 3)`, `True`.
- `/home/bernalde/.pixi/bin/pixi run -e gurobi pytest tests/test_release_workflow.py -v --tb=short` -> 5 passed.
- Direct Pyomo/Gurobi smoke solve through `gurobi_direct` -> `ok`, `optimal`, objective `4.0`.
- `git diff --check` -> passed.

## Solver-backed benchmark evidence

The benchmark comparisons now include GAMS/Gurobi cases for all direct GDP reformulations in this PR scope (`gdp.bigm` and `gdp.hull`), in addition to the local DICOPT and global BARON profiles. The GAMS/Gurobi rows below were run through the benchmark CLI with `--solver-profile gams-gurobi`, so they use the same single-threaded GAMS options as the other campaign rows.

Commands:

```bash
/home/bernalde/.pixi/bin/pixi run gdplib-benchmark run --instances gdp_col --strategies gdp.hull gdpopt.gloa gdpopt.lbb --timelimit 300 --solver-profile gams-local --run-id issue66_local_5min_20260511
/home/bernalde/.pixi/bin/pixi run gdplib-benchmark run --instances gdp_col --strategies gdp.hull gdpopt.gloa gdpopt.lbb --timelimit 300 --solver-profile gams-baron --run-id issue66_global_5min_20260511
/home/bernalde/.pixi/bin/pixi run -e gurobi gdplib-benchmark run --instances gdp_col --strategies gdp.bigm gdp.hull --timelimit 300 --solver-profile gams-gurobi --run-id issue66_gurobi_5min_20260511 --no-summary
```

| Profile | Strategy | Solver | Termination | Status | Objective | Lower bound | Upper bound | User time (s) |
|---|---|---|---|---|---:|---:|---:|---:|
| gams-local | gdp.hull | DICOPT | intermediateNonInteger | warning | 10273.524906 | 13110.109796 | 10273.524906 | 3.516 |
| gams-gurobi | gdp.bigm | Gurobi | maxTimeLimit | ok |  | 11014.509755 |  | 300.289 |
| gams-gurobi | gdp.hull | Gurobi | feasible | ok | 22355.240680 | 19223.858427 | 22355.240680 | 300.047 |
| gams-baron | gdp.hull | BARON | infeasible | ok |  | 1000.000000 |  | 0.423 |
| gams-local | gdpopt.gloa | DICOPT/IPOPTH/Gurobi roles | optimal | ok | 20916.392216 | 20916.392216 | 20916.392216 | 29.078 |
| gams-baron | gdpopt.gloa | BARON roles | maxTimeLimit | ok | 22355.240679 | 8000.000000 | 22355.240679 | 302.049 |
| gams-local | gdpopt.lbb | DICOPT/IPOPTH/Gurobi roles | failure | error |  |  |  |  |
| gams-baron | gdpopt.lbb | BARON roles | failure | error |  |  |  |  |

Additional Gurobi checks:
- GAMS/Gurobi accepts both direct reformulations as nonconvex MINLPs.
- For `gdp.hull`, GAMS/Gurobi finds a feasible incumbent at objective `22355.24067954157` within 300 seconds.
- For `gdp.bigm`, Gurobi reaches the 300-second time limit with no incumbent (`Solution count 0`, `Best objective -`) and a lower bound of `11014.509754975745`. The GAMS wrapper reports `OBJVAL`/upper bound as `17000.0`, but the Gurobi log does not support treating that as a valid incumbent, so the table leaves objective and upper bound blank.
- Pyomo's direct Gurobi interfaces are available in the optional Pixi environment, but they cannot currently write this nonlinear transformed hull instance directly: `gurobi` rejects nonlinear LP-format output, while `gurobi_direct` and `appsi_gurobi` reject expression degree `None`.
- Future solver-backed benchmark comparison tables should include the `gams-gurobi` profile for each direct reformulation alongside `gams-local` and `gams-baron` when Gurobi is licensed locally.

## Notes

- `gdp.hull` now transforms cleanly, but direct DICOPT and BARON behavior remains solver/formulation sensitive: DICOPT stops with `intermediateNonInteger`, while BARON reports the transformed hull model infeasible despite GAMS/Gurobi finding a feasible incumbent.
- `gdpopt.lbb` remains blocked by Pyomo GDPopt runtime behavior: `GDP_LBB_Solver` calls stale `_get_final_results_object()` in the time-limit path. I opened upstream Pyomo issue https://github.com/Pyomo/pyomo/issues/3941 with a minimal reproducer.
- Generated benchmark artifacts were not committed. Per-case JSON/log files from the local checks remain under ignored benchmark output directories.

Closes #66
