### PR TITLE
Fix ex1_linan_2023 Hull reformulation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,7 +74,9 @@ These instructions apply to the whole repository.
   `git diff --check`, and avoid unrelated normalization.
 - For GitHub issue or PR inspection through `gh`, prefer explicit `--json`
   field lists when default views request deprecated GraphQL fields such as
-  Projects Classic `projectCards`.
+  Projects Classic `projectCards`. GitHub rejects approvals from the PR author;
+  submit a `COMMENT` review instead and note that an eligible reviewer is still
+  required.
 - Match CI formatting and linting:
   ```bash
   black -S -C --target-version py310 --check --diff .
@@ -203,7 +205,10 @@ These instructions apply to the whole repository.
   instance, strategy/transformation, solver interface, GAMS solver and GDPopt
   role solvers when applicable, time limit, termination condition, objective
   value, primal/dual bounds, gap or infeasibility evidence, and failure log path
-  or traceback for errors.
+  or traceback for errors. If claiming coverage across alternatives or solvers,
+  name the exact benchmark strategies and solver profiles tested, and report
+  solver-wrapper caveats such as missing objective or bound fields even when the
+  termination condition is optimal.
 - For BARON infeasibility investigations, use `CompIIS` when useful and keep
   the IIS reproduction separate from exploratory verbose solver runs. Generate
   GAMS files with `symbolic_solver_labels=True`, include a GAMS-to-Pyomo symbol
@@ -262,10 +267,17 @@ These instructions apply to the whole repository.
   committed environment. Prefer direct `gdp.bigm` smoke tests when that is the
   intended path; do not add optional dependencies such as `sympy` solely to test
   a transformation path that the project does not otherwise require.
+- When model semantics require exactly one disjunct, declare the `Disjunction`
+  with `xor=True`; do not rely only on a separate `LogicalConstraint` because
+  `gdp.hull` requires XOR disjunctions.
 - For algebraic GDP reformulations, add deterministic equivalence tests on
   representative initialized data and smoke-test supported transformations such
   as `gdp.bigm` and `gdp.hull`. Keep this separate from solver-backed
   optimality evidence.
+- For polynomial objectives or constraints involving negative-bounded variables,
+  prefer explicit products for small integer powers when Pyomo/GDPopt FBBT or
+  interval propagation fails on `PowExpression`; keep the algebra equivalent and
+  add a focused regression test for the expression form or solve path.
 - For ordered-location superstructures or activation-prefix rewrites, test the
   discrete semantics directly on a small representative instance. Enumerate the
   relevant binary activation/location choices and assert the intended valid
@@ -290,9 +302,10 @@ These instructions apply to the whole repository.
   Pyomo's direct Gurobi solver interfaces. Pyomo's direct Gurobi writers do not
   support every nonlinear transformed GDP expression; for those cases, keep
   using the GAMS/Gurobi profile and record the limitation.
-- Packaging tests can regenerate `gdplib/_version.py` and the editable package
-  entry in `pixi.lock`. Do not commit that churn unless the task is explicitly
-  about versioning, release metadata, or regenerating the Pixi lock.
+- Packaging tests, Pixi runs, and benchmark runs can regenerate
+  `gdplib/_version.py` or the editable package entry in `pixi.lock`. Do not
+  commit that churn unless the task is explicitly about versioning, release
+  metadata, or regenerating the Pixi lock.
 - When changing release workflow or Pixi support policy docs, update
   `tests/test_release_workflow.py` so README, `publish.yml`, `pixi.toml`, and
   AGENTS.md stay aligned.

--- a/gdplib/ex1_linan_2023/ex1_linan_2023.py
+++ b/gdplib/ex1_linan_2023/ex1_linan_2023.py
@@ -62,13 +62,18 @@ def build_model():
         Pyomo.Objective
             Build the objective function of the toy problem
         """
+        alpha2 = m.alpha * m.alpha
+        alpha4 = alpha2 * alpha2
+        alpha6 = alpha4 * alpha2
+        beta2 = m.beta * m.beta
+        beta4 = beta2 * beta2
         return (
-            4 * (pow(m.alpha, 2))
-            - 2.1 * (pow(m.alpha, 4))
-            + (1 / 3) * (pow(m.alpha, 6))
+            4 * alpha2
+            - 2.1 * alpha4
+            + (1 / 3) * alpha6
             + m.alpha * m.beta
-            - 4 * (pow(m.beta, 2))
-            + 4 * (pow(m.beta, 4))
+            - 4 * beta2
+            + 4 * beta4
         )
 
     m.obj = pyo.Objective(rule=obj_fun, sense=pyo.minimize, doc="Objective function")

--- a/gdplib/ex1_linan_2023/ex1_linan_2023.py
+++ b/gdplib/ex1_linan_2023/ex1_linan_2023.py
@@ -125,7 +125,7 @@ def build_model():
         """
         return [m.Y1_disjunct[j] for j in m.set1]
 
-    m.Disjunction1 = Disjunction(rule=Disjunction1, xor=False)
+    m.Disjunction1 = Disjunction(rule=Disjunction1, xor=True)
 
     # Second disjunction
     def build_disjuncts2(m, set2):  # Disjuncts for second Boolean variable
@@ -179,7 +179,7 @@ def build_model():
         """
         return [m.Y2_disjunct[j] for j in m.set2]
 
-    m.Disjunction2 = Disjunction(rule=Disjunction2, xor=False)
+    m.Disjunction2 = Disjunction(rule=Disjunction2, xor=True)
 
     # Logical constraints
 

--- a/tests/test_ex1_linan_2023.py
+++ b/tests/test_ex1_linan_2023.py
@@ -1,0 +1,23 @@
+import pytest
+import pyomo.environ as pyo
+from pyomo.gdp import Disjunct, Disjunction
+
+from gdplib.ex1_linan_2023 import build_model
+
+
+def test_ex1_linan_disjunctions_are_xor():
+    model = build_model()
+
+    assert model.Disjunction1.xor is True
+    assert model.Disjunction2.xor is True
+
+
+@pytest.mark.parametrize("transformation", ["gdp.bigm", "gdp.hull"])
+def test_ex1_linan_reformulates_with_supported_gdp_transformations(transformation):
+    model = build_model()
+
+    pyo.TransformationFactory(transformation).apply_to(model)
+
+    assert not any(model.component_data_objects(pyo.LogicalConstraint, active=True))
+    assert not any(model.component_data_objects(Disjunction, active=True))
+    assert not any(model.component_data_objects(Disjunct, active=True))

--- a/tests/test_ex1_linan_2023.py
+++ b/tests/test_ex1_linan_2023.py
@@ -1,8 +1,16 @@
 import pytest
 import pyomo.environ as pyo
+from pyomo.core.expr.numeric_expr import PowExpression
+from pyomo.core.expr.visitor import identify_components
 from pyomo.gdp import Disjunct, Disjunction
 
 from gdplib.ex1_linan_2023 import build_model
+
+
+def test_ex1_linan_objective_avoids_power_expressions_for_gdpopt_fbbt():
+    model = build_model()
+
+    assert not list(identify_components(model.obj.expr, (PowExpression,)))
 
 
 def test_ex1_linan_disjunctions_are_xor():


### PR DESCRIPTION
Summary
- Make the two `ex1_linan_2023` disjunctions explicit XOR disjunctions so Pyomo's Hull reformulation accepts the model.
- Rewrite the even-power polynomial objective as algebraically equivalent products so GDPopt FBBT does not hit Pyomo's `PowExpression` interval inversion path for negative-bounded variables.
- Add focused regression coverage for the model's XOR semantics, objective expression form, and both direct GDP transformations.
- Update `AGENTS.md` with reusable, scoped guidance from this fix and review cycle.

Solver-backed benchmark evidence

All seven benchmark strategies completed with zero failures for the three named benchmark solver profiles using a 300 second time limit:

| Run id | Solver profile | Strategy cases | Failures | Notes |
|---|---|---:|---:|---|
| `pr127_ex1_linan_local_full_20260511` | `gams-local` (`DICOPT`, `IPOPTH`, `Gurobi` roles) | 7 | 0 | All optimal. Direct Big-M/DICOPT returned the local objective `-0.660209666967283`; Hull and GDPopt strategies returned `-0.9996` or equivalent. |
| `pr127_ex1_linan_baron_full_20260511` | `gams-baron` (`BARON` roles) | 7 | 0 | All optimal at objective `-0.9996` or equivalent. |
| `pr127_ex1_linan_gurobi_full_20260511` | `gams-gurobi` (`Gurobi`, `IPOPTH` NLP role) | 7 | 0 | All optimal. GDPopt LBB reported optimal but did not populate objective/bound fields in the JSON result. |

Benchmark commands:
- `pixi run gdplib-benchmark run --instances ex1_linan_2023 --strategies gdp.bigm gdp.hull gdpopt.enumerate gdpopt.loa gdpopt.gloa gdpopt.lbb gdpopt.ric --timelimit 300 --solver-profile gams-local --run-id pr127_ex1_linan_local_full_20260511 --no-skip-existing --no-summary`
- `pixi run gdplib-benchmark run --instances ex1_linan_2023 --strategies gdp.bigm gdp.hull gdpopt.enumerate gdpopt.loa gdpopt.gloa gdpopt.lbb gdpopt.ric --timelimit 300 --solver-profile gams-baron --run-id pr127_ex1_linan_baron_full_20260511 --no-skip-existing --no-summary`
- `pixi run gdplib-benchmark run --instances ex1_linan_2023 --strategies gdp.bigm gdp.hull gdpopt.enumerate gdpopt.loa gdpopt.gloa gdpopt.lbb gdpopt.ric --timelimit 300 --solver-profile gams-gurobi --run-id pr127_ex1_linan_gurobi_full_20260511 --no-skip-existing --no-summary`

Tests run
- `pixi run pytest tests/test_ex1_linan_2023.py -v --tb=short` - passed, 4 passed.
- `pixi run pytest tests/test_module_imports.py -v --tb=short` - passed, 68 passed.
- `pixi run pytest tests/test_release_workflow.py -v --tb=short` - passed, 5 passed.
- `pixi run pytest tests/ -v --tb=short` - passed, 281 passed, 1 skipped.
- `pixi run black -S -C --target-version py310 --check --diff .` - passed, 82 files would be left unchanged.
- `pixi run flake8 gdplib/ --count --select=E9,F63,F7,F82 --show-source --statistics` - passed, output `0`.
- `pixi run flake8 gdplib/ --count --exit-zero --max-complexity=10 --max-line-length=88 --statistics` - completed with exit code 0 and reported existing repository style findings.
- `pixi run typos --config ./.github/workflows/typos.toml` - passed.
- `git diff --check` - passed.

Notes
- Generated benchmark artifacts are intentionally not committed.
- Pixi regenerated editable-package metadata in `pixi.lock` during local verification; that generated churn was restored and is not included.

Closes #65
