### PR TITLE
Fix small_batch GLOA bounds

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -274,10 +274,12 @@ These instructions apply to the whole repository.
   representative initialized data and smoke-test supported transformations such
   as `gdp.bigm` and `gdp.hull`. Keep this separate from solver-backed
   optimality evidence.
-- For polynomial objectives or constraints involving negative-bounded variables,
-  prefer explicit products for small integer powers when Pyomo/GDPopt FBBT or
-  interval propagation fails on `PowExpression`; keep the algebra equivalent and
-  add a focused regression test for the expression form or solve path.
+- When Pyomo/GDPopt FBBT or interval propagation fails, fix the narrow
+  modeling cause before changing solver configuration: derive finite bounds from
+  source constraints and parameters for missing-bound failures, and use explicit
+  products for small integer powers when negative-bounded variables break
+  `PowExpression`. Keep algebra equivalent and verify the affected
+  transformation or GDPopt path when practical.
 - For ordered-location superstructures or activation-prefix rewrites, test the
   discrete semantics directly on a small representative instance. Enumerate the
   relevant binary activation/location choices and assert the intended valid

--- a/gdplib/small_batch/gdp_small_batch.py
+++ b/gdplib/small_batch/gdp_small_batch.py
@@ -12,6 +12,7 @@ References
 
 """
 
+import math
 import os
 import pyomo.environ as pyo
 from pyomo.core.base.misc import display
@@ -135,6 +136,17 @@ def build_model():
         m.i, m.j, initialize=t_init, doc="Processing time of product i in batch j [hr]"
     )
 
+    def batch_size_bounds(m, i):
+        batch_size_ub = min(
+            math.log(pyo.value(m.vupp) / pyo.value(m.s[i, j])) for j in m.j
+        )
+        return (0, batch_size_ub)
+
+    def cycle_time_bounds(m, i):
+        _, batch_size_ub = batch_size_bounds(m, i)
+        cycle_time_ub = math.log(pyo.value(m.h) / pyo.value(m.q[i])) + batch_size_ub
+        return (0, cycle_time_ub)
+
     # Variables
     m.Y = pyo.BooleanVar(m.k, m.j, doc="Stage existence")  # Stage existence
     m.coeffval = pyo.Var(
@@ -151,14 +163,23 @@ def build_model():
         doc="Volume of stage j [L]",
     )  # Volume of stage j [L]
     m.b = pyo.Var(
-        m.i, within=pyo.NonNegativeReals, doc="Batch size of product i [L]"
+        m.i,
+        within=pyo.NonNegativeReals,
+        bounds=batch_size_bounds,
+        doc="Batch size of product i [L]",
     )  # Batch size of product i [L]
     m.tl = pyo.Var(
-        m.i, within=pyo.NonNegativeReals, doc="Cycle time of product i [hr]"
+        m.i,
+        within=pyo.NonNegativeReals,
+        bounds=cycle_time_bounds,
+        doc="Cycle time of product i [hr]",
     )  # Cycle time of product i [hr]
     # Number of units in parallel stage j
     m.n = pyo.Var(
-        m.j, within=pyo.NonNegativeReals, doc="Number of units in parallel stage j"
+        m.j,
+        within=pyo.NonNegativeReals,
+        bounds=(0, math.log(NK)),
+        doc="Number of units in parallel stage j",
     )
 
     # Constraints

--- a/tests/test_small_batch.py
+++ b/tests/test_small_batch.py
@@ -1,0 +1,39 @@
+import math
+
+import pytest
+import pyomo.environ as pyo
+from pyomo.environ import value
+from pyomo.gdp import Disjunction
+
+import gdplib.small_batch
+
+
+def test_small_batch_log_variables_have_finite_source_bounds():
+    model = gdplib.small_batch.build_model()
+
+    for j in model.j:
+        assert model.n[j].lb == 0
+        assert model.n[j].ub == pytest.approx(math.log(len(model.k)))
+
+    for i in model.i:
+        expected_batch_size_ub = min(
+            math.log(value(model.vupp) / value(model.s[i, j])) for j in model.j
+        )
+        expected_cycle_time_ub = (
+            math.log(value(model.h) / value(model.q[i])) + expected_batch_size_ub
+        )
+
+        assert model.b[i].lb == 0
+        assert model.b[i].ub == pytest.approx(expected_batch_size_ub)
+        assert model.tl[i].lb == 0
+        assert model.tl[i].ub == pytest.approx(expected_cycle_time_ub)
+
+
+@pytest.mark.parametrize("transformation", ["gdp.bigm", "gdp.hull"])
+def test_small_batch_reformulates_with_bounded_log_variables(transformation):
+    model = gdplib.small_batch.build_model()
+
+    pyo.TransformationFactory(transformation).apply_to(model)
+
+    assert not any(model.component_data_objects(pyo.LogicalConstraint, active=True))
+    assert not any(model.component_data_objects(Disjunction, active=True))


### PR DESCRIPTION
## Summary

- Adds finite, source-derived upper bounds to the `small_batch` log batch-size, log cycle-time, and log parallel-unit variables.
- Keeps the `small_batch` model solver-free at construction time while avoiding GDPopt GLOA's FBBT failure from missing bounds.
- Adds focused solver-free tests for those bounds and for `gdp.bigm`/`gdp.hull` reformulation smoke coverage.

## Tests run

- `pixi run pytest tests/test_small_batch.py tests/test_pyomo_deprecations.py::test_small_batch_bigm_avoids_boolean_indicator_conversion -v --tb=short` - passed, 4 tests.
- `pixi run pytest tests/test_module_imports.py -v --tb=short` - passed, 68 tests.
- `pixi run test` - passed, 284 passed, 1 skipped.
- `pixi run lint` - passed. The repository's lint task prints the existing non-fatal general flake8 inventory because that step uses `--exit-zero`; Black, critical flake8, and typos completed successfully.
- `pixi run gdplib-benchmark preflight --instances small_batch --strategies gdpopt.gloa --solver-profile gams-local --timelimit 60` - passed.
- `pixi run gdplib-benchmark run --instances small_batch --strategies gdpopt.gloa --solver-profile gams-local --timelimit 60 --run-id issue74_small_batch_gloa_postpatch --no-summary --no-skip-existing --fail-fast` - passed with `optimal`, objective `167427.65700406412`, lower bound `167427.65700406412`, upper bound `167427.65700406412`.

## Notes

- No separate type-check command was found in the documented project commands.
- Generated benchmark artifacts were left under ignored benchmark output paths and are not part of this PR.
- Follow-up issue #104 concerns PyPI release workflow and Pixi platform policy, so this model-only PR does not change packaging, release workflow, Pixi platforms, or `pixi.lock`.

Closes #74
