### PR TITLE
Fix batch_processing GLOA bounds

### DIFF
--- a/gdplib/batch_processing/batch_processing.py
+++ b/gdplib/batch_processing/batch_processing.py
@@ -64,6 +64,8 @@ def build_model():
     StorageTankSizeUB = log(15000)
     UnitsInPhaseUB = log(6)
     UnitsOutOfPhaseUB = log(6)
+    BatchSizeLogLB = 0
+    BatchSizeLogUB = 10
     # TODO: YOU ARE HERE. YOU HAVEN'T ACTUALLY MADE THESE THE BOUNDS YET, NOR HAVE YOU FIGURED OUT WHOSE
     # BOUNDS THEY ARE. AND THERE ARE MORE IN GAMS.
 
@@ -219,11 +221,35 @@ def build_model():
     model.batchSize_log = Var(
         model.PRODUCTS,
         model.STAGES,
-        bounds=(0, 10),
+        bounds=(BatchSizeLogLB, BatchSizeLogUB),
         doc="Logarithmic Batch Size of the Products",
     )
+
+    def get_cycleTime_bounds(model, i):
+        """
+        Derives finite bounds for the logarithmic cycle time of each product.
+
+        The lower bound follows from the processing-time constraints using the
+        largest allowed batch size and out-of-phase unit count. The upper bound
+        follows from the horizon constraint because each positive production
+        term must fit within the time horizon.
+        """
+        lower_bound = max(
+            value(
+                log(model.ProcessingTime[i, j])
+                - BatchSizeLogUB
+                - model.unitsOutOfPhaseUB[j]
+            )
+            for j in model.STAGES
+        )
+        upper_bound = value(log(model.HorizonTime / model.ProductionAmount[i]))
+
+        return (lower_bound, upper_bound)
+
     model.cycleTime_log = Var(
-        model.PRODUCTS, doc="Logarithmic Cycle Time of the Products"
+        model.PRODUCTS,
+        bounds=get_cycleTime_bounds,
+        doc="Logarithmic Cycle Time of the Products",
     )
 
     def get_unitsOutOfPhase_bounds(model, j):

--- a/gdplib/batch_processing/batch_processing.py
+++ b/gdplib/batch_processing/batch_processing.py
@@ -64,10 +64,12 @@ def build_model():
     StorageTankSizeUB = log(15000)
     UnitsInPhaseUB = log(6)
     UnitsOutOfPhaseUB = log(6)
+    # Log-space batch-size box carried over from the original GAMS source
+    # (Batch101006_BM.gms, not committed here); the cycleTime_log bounds
+    # derived in get_cycleTime_bounds below depend on this upper bound.
+    # TODO: trace the remaining GAMS bounds for the other log-space variables.
     BatchSizeLogLB = 0
     BatchSizeLogUB = 10
-    # TODO: YOU ARE HERE. YOU HAVEN'T ACTUALLY MADE THESE THE BOUNDS YET, NOR HAVE YOU FIGURED OUT WHOSE
-    # BOUNDS THEY ARE. AND THERE ARE MORE IN GAMS.
 
     # Sets
 

--- a/tests/test_batch_processing.py
+++ b/tests/test_batch_processing.py
@@ -1,0 +1,82 @@
+import math
+import os
+
+import pytest
+import pyomo.environ as pyo
+from pyomo.contrib.fbbt.fbbt import fbbt
+from pyomo.gdp import Disjunct, Disjunction
+from pyomo.opt import TerminationCondition
+
+from gdplib.batch_processing import build_model
+from gdplib.benchmark import _gdpopt_solve_kwargs
+
+
+def test_batch_processing_cycle_time_log_has_finite_source_bounds():
+    model = build_model()
+
+    for i in model.PRODUCTS:
+        expected_lb = max(
+            math.log(pyo.value(model.ProcessingTime[i, j]))
+            - pyo.value(model.batchSize_log[i, j].ub)
+            - pyo.value(model.unitsOutOfPhaseUB[j])
+            for j in model.STAGES
+        )
+        expected_ub = math.log(
+            pyo.value(model.HorizonTime) / pyo.value(model.ProductionAmount[i])
+        )
+
+        assert model.cycleTime_log[i].lb == pytest.approx(expected_lb)
+        assert model.cycleTime_log[i].ub == pytest.approx(expected_ub)
+
+
+def test_batch_processing_fbbt_handles_cycle_time_bounds():
+    model = build_model()
+
+    fbbt(model)
+
+    for i in model.PRODUCTS:
+        assert math.isfinite(model.cycleTime_log[i].lb)
+        assert math.isfinite(model.cycleTime_log[i].ub)
+
+
+@pytest.mark.parametrize("transformation", ["gdp.bigm", "gdp.hull"])
+def test_batch_processing_reformulates_with_supported_gdp_transformations(
+    transformation,
+):
+    model = build_model()
+
+    pyo.TransformationFactory(transformation).apply_to(model)
+
+    assert not any(model.component_data_objects(pyo.LogicalConstraint, active=True))
+    assert not any(model.component_data_objects(Disjunction, active=True))
+    assert not any(model.component_data_objects(Disjunct, active=True))
+
+
+@pytest.mark.skipif(
+    os.environ.get("GDPLIB_RUN_GAMS_BARON_TESTS") != "1",
+    reason="set GDPLIB_RUN_GAMS_BARON_TESTS=1 to run optional GAMS/BARON tests",
+)
+def test_batch_processing_gloa_runs_with_gams_baron():
+    if not pyo.SolverFactory("gams").available(False):
+        pytest.skip("GAMS solver interface is not available")
+
+    model = build_model()
+    kwargs = _gdpopt_solve_kwargs(20, "gams", "baron")
+    kwargs["tee"] = False
+    for key in (
+        "nlp_solver_args",
+        "mip_solver_args",
+        "minlp_solver_args",
+        "local_minlp_solver_args",
+    ):
+        kwargs[key]["tee"] = False
+
+    results = pyo.SolverFactory("gdpopt.gloa").solve(model, **kwargs)
+
+    assert results.solver.termination_condition in {
+        TerminationCondition.optimal,
+        TerminationCondition.maxTimeLimit,
+    }
+    assert math.isfinite(results.problem.lower_bound)
+    assert math.isfinite(results.problem.upper_bound)
+    assert results.problem.lower_bound <= results.problem.upper_bound

--- a/tests/test_batch_processing.py
+++ b/tests/test_batch_processing.py
@@ -8,7 +8,34 @@ from pyomo.gdp import Disjunct, Disjunction
 from pyomo.opt import TerminationCondition
 
 from gdplib.batch_processing import build_model
-from gdplib.benchmark import _gdpopt_solve_kwargs
+
+
+def _gloa_gams_baron_kwargs(timelimit):
+    """Self-contained GDPopt kwargs for the GAMS/BARON smoke test.
+
+    Kept independent of gdplib.benchmark internals so benchmark refactors
+    cannot break this model regression test.
+    """
+
+    def _solver_args():
+        return dict(
+            solver="baron",
+            add_options=[f"option reslim={timelimit};", "option optcr=1e-6;"],
+            tee=False,
+        )
+
+    return {
+        "tee": False,
+        "time_limit": timelimit,
+        "nlp_solver": "gams",
+        "nlp_solver_args": _solver_args(),
+        "mip_solver": "gams",
+        "mip_solver_args": _solver_args(),
+        "minlp_solver": "gams",
+        "minlp_solver_args": _solver_args(),
+        "local_minlp_solver": "gams",
+        "local_minlp_solver_args": _solver_args(),
+    }
 
 
 def test_batch_processing_cycle_time_log_has_finite_source_bounds():
@@ -47,6 +74,9 @@ def test_batch_processing_reformulates_with_supported_gdp_transformations(
 
     pyo.TransformationFactory(transformation).apply_to(model)
 
+    # Forward guard: the model currently declares no LogicalConstraint (its
+    # XORs are algebraic), so this only fires if future edits add one that a
+    # transformation then fails to deactivate.
     assert not any(model.component_data_objects(pyo.LogicalConstraint, active=True))
     assert not any(model.component_data_objects(Disjunction, active=True))
     assert not any(model.component_data_objects(Disjunct, active=True))
@@ -61,15 +91,7 @@ def test_batch_processing_gloa_runs_with_gams_baron():
         pytest.skip("GAMS solver interface is not available")
 
     model = build_model()
-    kwargs = _gdpopt_solve_kwargs(20, "gams", "baron")
-    kwargs["tee"] = False
-    for key in (
-        "nlp_solver_args",
-        "mip_solver_args",
-        "minlp_solver_args",
-        "local_minlp_solver_args",
-    ):
-        kwargs[key]["tee"] = False
+    kwargs = _gloa_gams_baron_kwargs(20)
 
     results = pyo.SolverFactory("gdpopt.gloa").solve(model, **kwargs)
 


### PR DESCRIPTION
## Summary

- Add finite source-derived bounds for `batch_processing.cycleTime_log`.
- Preserve the existing `build_model()` API and solver-free construction path.
- Add focused regression tests for the derived bounds, FBBT, Big-M/Hull transformations, and an opt-in GAMS/BARON GLOA smoke.

## Tests run

- `/home/bernalde/.pixi/bin/pixi run pytest tests/test_batch_processing.py -v --tb=short`
  - Result: 4 passed, 1 skipped.
- `/home/bernalde/.pixi/bin/pixi run env GDPLIB_RUN_GAMS_BARON_TESTS=1 pytest tests/test_batch_processing.py::test_batch_processing_gloa_runs_with_gams_baron -v --tb=short`
  - Result: 1 passed.
- `/home/bernalde/.pixi/bin/pixi run pytest tests/test_module_imports.py -v --tb=short`
  - Result: 68 passed.
- `/home/bernalde/.pixi/bin/pixi run test`
  - Result: 288 passed, 2 skipped.
- `/home/bernalde/.pixi/bin/pixi run lint`
  - Result: passed with exit code 0. The non-blocking flake8 pass printed existing `--exit-zero` style statistics.
- `/home/bernalde/.pixi/bin/pixi run gdplib-benchmark run --instances batch_processing --strategies gdpopt.gloa --solver-profile gams-local --timelimit 120 --run-id issue61_postbounds_gloa_local_20260511`
  - Result: GLOA returned a normal `maxTimeLimit` solver result with finite lower/upper bounds instead of the pre-patch FBBT assertion. The CLI then exited while generating summaries because `generate_benchmark_summary_all` is not importable in this checkout.

## Notes

- A pre-patch GLOA/BARON reproduction emitted missing-upper-bound warnings for every `cycleTime_log[...]` variable and failed in Pyomo FBBT with `AssertionError`.
- I did not run a full 3600-second benchmark campaign; the focused solver smoke verifies the model-level bound failure no longer occurs.
- Follow-up issue #104 was reviewed and is closed release/Pixi planning work, so this PR intentionally does not change packaging, release, or Pixi platform policy.

Closes #61
