### PR TITLE
Fix biofuel site module constraints

### DIFF
--- a/gdplib/biofuel/model.py
+++ b/gdplib/biofuel/model.py
@@ -906,9 +906,9 @@ def _build_site_inactive_disjunct(disj, site):
             The constraint that there are no modules at the inactive site
         """
         return (
-            sum(m.num_modules[...])
-            + sum(m.modules_purchased[...])
-            + sum(m.modules_sold[...])
+            sum(m.num_modules[site, t] for t in m.time)
+            + sum(m.modules_purchased[site, t] for t in m.time)
+            + sum(m.modules_sold[site, t] for t in m.time)
             == 0
         )
 
@@ -1031,9 +1031,9 @@ def _build_conventional_disjunct(disj, site):
             A constraint that the number of modules (present, purchased, sold) at the site is zero.
         """
         return (
-            sum(m.num_modules[...])
-            + sum(m.modules_purchased[...])
-            + sum(m.modules_sold[...])
+            sum(m.num_modules[site, t] for t in m.time)
+            + sum(m.modules_purchased[site, t] for t in m.time)
+            + sum(m.modules_sold[site, t] for t in m.time)
             == 0
         )
 

--- a/tests/test_biofuel.py
+++ b/tests/test_biofuel.py
@@ -1,0 +1,42 @@
+import pytest
+import pyomo.environ as pyo
+from pyomo.core.expr.visitor import identify_variables
+from pyomo.gdp import Disjunct, Disjunction
+
+from gdplib.biofuel import build_model
+
+MODULE_COMPONENT_NAMES = {"num_modules", "modules_purchased", "modules_sold"}
+
+
+def _module_variable_sites(constraint):
+    sites = set()
+    for var in identify_variables(constraint.body, include_fixed=False):
+        if var.parent_component().local_name in MODULE_COMPONENT_NAMES:
+            sites.add(var.index()[0])
+    return sites
+
+
+@pytest.mark.parametrize(
+    "disjunct_name,constraint_name",
+    [("site_inactive", "no_modules"), ("conventional", "no_modules")],
+)
+def test_biofuel_site_disjunct_module_constraints_are_site_local(
+    disjunct_name, constraint_name
+):
+    model = build_model()
+
+    for site in model.potential_sites:
+        disjunct = getattr(model, disjunct_name)[site]
+        constraint = getattr(disjunct, constraint_name)
+
+        assert _module_variable_sites(constraint) == {site}
+
+
+@pytest.mark.parametrize("transformation", ["gdp.bigm", "gdp.hull"])
+def test_biofuel_reformulates_with_supported_gdp_transformations(transformation):
+    model = build_model()
+
+    pyo.TransformationFactory(transformation).apply_to(model)
+
+    assert not any(model.component_data_objects(Disjunction, active=True))
+    assert not any(model.component_data_objects(Disjunct, active=True))

--- a/tests/test_biofuel.py
+++ b/tests/test_biofuel.py
@@ -10,7 +10,9 @@ MODULE_COMPONENT_NAMES = {"num_modules", "modules_purchased", "modules_sold"}
 
 def _module_variable_sites(constraint):
     sites = set()
-    for var in identify_variables(constraint.body, include_fixed=False):
+    # include_fixed=True so the site set reflects the constraint algebra even
+    # for module variables fixed to zero during setup periods at build time.
+    for var in identify_variables(constraint.body, include_fixed=True):
         if var.parent_component().local_name in MODULE_COMPONENT_NAMES:
             sites.add(var.index()[0])
     return sites
@@ -40,3 +42,8 @@ def test_biofuel_reformulates_with_supported_gdp_transformations(transformation)
 
     assert not any(model.component_data_objects(Disjunction, active=True))
     assert not any(model.component_data_objects(Disjunct, active=True))
+    if transformation == "gdp.hull":
+        assert any(
+            "disaggregated" in var.name
+            for var in model.component_data_objects(pyo.Var, active=True)
+        )


### PR DESCRIPTION
## Summary

- Fix `biofuel` conventional and inactive site disjuncts so their `no_modules` constraints only reference module variables for the disjunct's own site.
- Add focused regression tests that verify those constraints are site-local and that `biofuel` still reformulates with `gdp.bigm` and `gdp.hull`.

## Tests run

- `pixi run pytest tests/test_biofuel.py -v --tb=short` - passed, 4 passed.
- `pixi run pytest 'tests/test_module_imports.py::TestModelConstruction::test_model_construction[biofuel]' -v --tb=short` - passed, 1 passed.
- `pixi run test` - passed, 288 passed and 1 skipped.
- `pixi run lint` - exited 0 after Black, critical flake8, non-blocking full flake8 report, and typos.
- `git diff --check` - passed.

## Notes

- No solver-backed benchmark campaign was run locally; the default test coverage remains solver-free and this change is limited to model algebra and GDP transformation smoke tests.
- Considered #104 while keeping release and Pixi platform policy out of scope for this model fix.

Closes #62
