### PR TITLE
Fix positioning GLOA benchmark initialization

### DIFF
--- a/gdplib/benchmark.py
+++ b/gdplib/benchmark.py
@@ -18,6 +18,7 @@ from importlib import import_module
 from pathlib import Path
 
 import pyomo
+from pyomo.common.collections import ComponentSet
 from pyomo.environ import SolverFactory, TransformationFactory
 
 try:
@@ -321,6 +322,19 @@ def _gdpopt_solve_kwargs(
     return kwargs
 
 
+def _gdpopt_model_initialization_kwargs(model):
+    initial_disjuncts = getattr(model, "gdpopt_initial_disjuncts", None)
+    if not initial_disjuncts:
+        return {}
+
+    return {
+        "init_algorithm": "custom_disjuncts",
+        "custom_init_disjuncts": [
+            ComponentSet(disjunct_set) for disjunct_set in initial_disjuncts
+        ],
+    }
+
+
 def _gdpopt_subsolvers(
     subsolver,
     solver_gams,
@@ -521,18 +535,17 @@ def benchmark(
             "w",
         ) as f:
             with redirect_stdout(f):
-                results = SolverFactory(strategy).solve(
-                    model,
-                    **_gdpopt_solve_kwargs(
-                        timelimit,
-                        subsolver,
-                        solver_gams,
-                        gams_nlp_solver,
-                        gams_mip_solver,
-                        gams_minlp_solver,
-                        gams_local_minlp_solver,
-                    ),
+                solve_kwargs = _gdpopt_solve_kwargs(
+                    timelimit,
+                    subsolver,
+                    solver_gams,
+                    gams_nlp_solver,
+                    gams_mip_solver,
+                    gams_minlp_solver,
+                    gams_local_minlp_solver,
                 )
+                solve_kwargs.update(_gdpopt_model_initialization_kwargs(model))
+                results = SolverFactory(strategy).solve(model, **solve_kwargs)
                 print(results)
     else:
         raise ValueError(f"Unknown benchmark strategy: {strategy}")

--- a/gdplib/benchmark.py
+++ b/gdplib/benchmark.py
@@ -34,6 +34,7 @@ GDPOPT_STRATEGIES = [
     "gdpopt.lbb",
     "gdpopt.ric",
 ]
+GDPOPT_CUSTOM_INIT_STRATEGIES = {"gdpopt.loa", "gdpopt.gloa", "gdpopt.ric"}
 DEFAULT_STRATEGIES = TRANSFORMATION_STRATEGIES + GDPOPT_STRATEGIES
 DEFAULT_LOCAL_FIRST_STRATEGIES = DEFAULT_STRATEGIES
 PR58_BENCHMARK_INSTANCES = [
@@ -322,7 +323,10 @@ def _gdpopt_solve_kwargs(
     return kwargs
 
 
-def _gdpopt_model_initialization_kwargs(model):
+def _gdpopt_model_initialization_kwargs(model, strategy):
+    if strategy not in GDPOPT_CUSTOM_INIT_STRATEGIES:
+        return {}
+
     initial_disjuncts = getattr(model, "gdpopt_initial_disjuncts", None)
     if not initial_disjuncts:
         return {}
@@ -544,7 +548,9 @@ def benchmark(
                     gams_minlp_solver,
                     gams_local_minlp_solver,
                 )
-                solve_kwargs.update(_gdpopt_model_initialization_kwargs(model))
+                solve_kwargs.update(
+                    _gdpopt_model_initialization_kwargs(model, strategy)
+                )
                 results = SolverFactory(strategy).solve(model, **solve_kwargs)
                 print(results)
     else:

--- a/gdplib/benchmark.py
+++ b/gdplib/benchmark.py
@@ -34,7 +34,7 @@ GDPOPT_STRATEGIES = [
     "gdpopt.lbb",
     "gdpopt.ric",
 ]
-GDPOPT_CUSTOM_INIT_STRATEGIES = {"gdpopt.loa", "gdpopt.gloa", "gdpopt.ric"}
+GDPOPT_CUSTOM_INIT_STRATEGIES = {"gdpopt.gloa"}
 DEFAULT_STRATEGIES = TRANSFORMATION_STRATEGIES + GDPOPT_STRATEGIES
 DEFAULT_LOCAL_FIRST_STRATEGIES = DEFAULT_STRATEGIES
 PR58_BENCHMARK_INSTANCES = [
@@ -323,7 +323,20 @@ def _gdpopt_solve_kwargs(
     return kwargs
 
 
-def _gdpopt_model_initialization_kwargs(model, strategy):
+def _gdpopt_model_initialization_kwargs(model, strategy, custom_init=False):
+    """Opt-in GDPopt warm start from a model-provided active-disjunct set.
+
+    Protocol: a model may expose ``model.gdpopt_initial_disjuncts``, a list of
+    iterables of Disjunct objects (one iterable per initialization subproblem)
+    describing a known-feasible active set. It is consumed only when the
+    benchmark run explicitly opts in (``--custom-init``) and the strategy is in
+    ``GDPOPT_CUSTOM_INIT_STRATEGIES``; runs using it are labeled in the result
+    metadata, because a warm-started row measures verification of the provided
+    set, not cold-start solving.
+    """
+    if not custom_init:
+        return {}
+
     if strategy not in GDPOPT_CUSTOM_INIT_STRATEGIES:
         return {}
 
@@ -377,12 +390,15 @@ def _benchmark_metadata(
     gams_minlp_solver=None,
     gams_local_minlp_solver=None,
     label=None,
+    custom_init=False,
 ):
     metadata = {
         "Strategy": strategy,
         "Time limit": timelimit,
         "Solver interface": subsolver,
     }
+    if strategy in GDPOPT_STRATEGIES:
+        metadata["Initialization"] = "custom_disjuncts" if custom_init else "default"
     if label:
         metadata["Case label"] = label
     if solver_profile:
@@ -427,6 +443,7 @@ def _write_results_json(
     gams_minlp_solver=None,
     gams_local_minlp_solver=None,
     label=None,
+    custom_init=False,
 ):
     payload = results.json_repn()
     payload["Benchmark"] = [
@@ -441,6 +458,7 @@ def _write_results_json(
             gams_minlp_solver,
             gams_local_minlp_solver,
             label,
+            custom_init,
         )
     ]
     payload = _json_safe_result(payload)
@@ -481,8 +499,13 @@ def benchmark(
     gams_minlp_solver=None,
     gams_local_minlp_solver=None,
     label=None,
+    custom_init=False,
 ):
     """Benchmark the model using the given strategy and subsolver.
+
+    When ``custom_init`` is true and the model exposes
+    ``gdpopt_initial_disjuncts``, supported GDPopt strategies are warm-started
+    from that active set and the result metadata is labeled accordingly.
 
     The result files include solver output and a JSON representation of the results.
 
@@ -549,7 +572,7 @@ def benchmark(
                     gams_local_minlp_solver,
                 )
                 solve_kwargs.update(
-                    _gdpopt_model_initialization_kwargs(model, strategy)
+                    _gdpopt_model_initialization_kwargs(model, strategy, custom_init)
                 )
                 results = SolverFactory(strategy).solve(model, **solve_kwargs)
                 print(results)
@@ -569,6 +592,7 @@ def benchmark(
         gams_minlp_solver,
         gams_local_minlp_solver,
         label,
+        custom_init,
     )
     return None
 
@@ -1367,6 +1391,7 @@ def run_benchmark_campaign(args, stream=None):  # noqa: C901
                     case.gams_minlp_solver,
                     case.gams_local_minlp_solver,
                     case.label,
+                    custom_init=getattr(args, "custom_init", False),
                 )
             except Exception as err:
                 failure_path = _write_failure_log(
@@ -1711,6 +1736,18 @@ def _build_parser():
         "--skip-preflight",
         action="store_true",
         help="Start solves without running preflight checks first.",
+    )
+    run.add_argument(
+        "--custom-init",
+        dest="custom_init",
+        action="store_true",
+        default=False,
+        help=(
+            "Warm-start supported GDPopt strategies from a model-provided "
+            "gdpopt_initial_disjuncts active set. Warm-started rows are "
+            "labeled in the result metadata and are not comparable with "
+            "cold-start rows."
+        ),
     )
     run.add_argument(
         "--dry-run",

--- a/gdplib/positioning/README.md
+++ b/gdplib/positioning/README.md
@@ -10,7 +10,17 @@ Source paper (Example 4):
 
 ### Solution
 
-Optimal objective value: -8.06
+Best known objective value: -8.06 (optimal)
+
+The benchmark `gdpopt.gloa` custom-disjunct initialization marks consumers
+1, 6, 8, 15, 17, 20, and 25 as active for the default model instance. In
+PR #145, this active set was cross-checked by solving the Big-M reformulation
+with GAMS/BARON, which reported optimal termination with objective
+-8.0641361647335, `U = 0`, and the same selected consumers. The same active
+set initialized `pixi run gdplib-benchmark run --instances positioning
+--strategies gdpopt.gloa --timelimit 60 --run-id
+issue73_positioning_gloa_custom_init_60s`, which reported optimal termination
+with lower bound, upper bound, and objective -8.0641361676497.
 
 ### Size
 
@@ -24,4 +34,3 @@ Optimal objective value: -8.06
 | Disjuncts             |       50 |
 | Constraints           |       30 |
 | Nonlinear constraints |       25 |
-

--- a/gdplib/positioning/README.md
+++ b/gdplib/positioning/README.md
@@ -22,6 +22,17 @@ set initialized `pixi run gdplib-benchmark run --instances positioning
 issue73_positioning_gloa_custom_init_60s`, which reported optimal termination
 with lower bound, upper bound, and objective -8.0641361676497.
 
+The warm start is opt-in: benchmark runs use it only with `--custom-init`,
+and warm-started result rows are labeled `Initialization: custom_disjuncts`
+in the result metadata, since they verify the recorded active set rather
+than measure cold-start solving.
+
+Besides the initialization, PR #145 also tightens the `U` variable bounds
+from (0, 5000) to the largest consumer slack implied by the data. This is a
+valid implied bound (the per-coordinate corner maximum is exact for the
+positive weights), but it does shrink the `(x, Y, U)` variable box relative
+to earlier gdplib versions.
+
 ### Size
 
 | Component             |   Number |

--- a/gdplib/positioning/positioning.py
+++ b/gdplib/positioning/positioning.py
@@ -233,16 +233,46 @@ def build_model():
     # minimum dissimilarity between the existing products and consumers' ideal points
     r = {i: min(rr[i, j] for j in m.products) for i in m.consumers}
 
-    m.x = Var(m.locations, doc="Location of each product")
+    def _location_bounds(m, k):
+        return location_bounds[k]
+
+    m.x = Var(m.locations, bounds=_location_bounds, doc="Location of each product")
     m.Y = BooleanVar(
         m.consumers,
         doc="Indicates if consumer positioning is satisfactory based on distance to ideal points.",
     )
+    consumer_slack_bound = {}
+    for i in m.consumers:
+        max_distance = sum(
+            value(m.weights[i, k])
+            * max(
+                (location_bounds[k][0] - value(m.ideal_points[i, k])) ** 2,
+                (location_bounds[k][1] - value(m.ideal_points[i, k])) ** 2,
+            )
+            for k in m.locations
+        )
+        consumer_slack_bound[i] = max(0, max_distance - value(r[i]))
+
+    m.consumer_slack_bound = Param(
+        m.consumers,
+        initialize=consumer_slack_bound,
+        doc="Valid upper bound on each consumer distance slack",
+    )
     m.H = Param(initialize=1000, doc="Big M value")
     m.U = Var(
-        bounds=(0, 5000),
+        bounds=(0, max(consumer_slack_bound.values())),
         doc="Upper bound on the sum of the distances to the ideal points",
     )  # Slack variable
+
+    @m.Expression(m.consumers)
+    def distance_slack(m, i):
+        return (
+            sum(
+                m.weights[i, k] * (m.x[k] - m.ideal_points[i, k]) ** 2
+                for k in m.locations
+            )
+            - r[i]
+        )
 
     @m.Disjunction(m.consumers)
     def d(m, i):
@@ -261,24 +291,23 @@ def build_model():
         Pyomo.Disjunction
             A Pyomo Disjunction object that evaluates if the consumer's preference is met (`true` scenario) with a single Pyomo expression, or not met (`false` scenario) where the list is empty.
         """
-        return [
-            [
-                sum(
-                    m.weights[i, k] * (m.x[k] - m.ideal_points[i, k]) ** 2
-                    for k in m.locations
-                )
-                - r[i]
-                <= m.U
-            ],
-            [],
-        ]
+        return [[m.distance_slack[i] <= m.U], []]
 
     for i in m.consumers:
         m.Y[i].associate_binary_var(m.d[i].disjuncts[0].binary_indicator_var)
-    for k in m.locations:
-        lb, ub = location_bounds[k]
-        m.x[k].setlb(lb)
-        m.x[k].setub(ub)
+
+    # BARON-verified active set for GDPOpt custom-disjunct initialization.
+    gdpopt_initial_consumers = {1, 6, 8, 15, 17, 20, 25}
+    m.gdpopt_initial_disjuncts = [
+        tuple(
+            (
+                m.d[i].disjuncts[0]
+                if i in gdpopt_initial_consumers
+                else m.d[i].disjuncts[1]
+            )
+            for i in m.consumers
+        )
+    ]
 
     m.c1 = Constraint(
         expr=m.x[1] - m.x[2] + m.x[3] + m.x[4] + m.x[5] <= 10, doc="Constraint 1"

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -2,12 +2,14 @@ import json
 from pathlib import Path
 from types import SimpleNamespace
 
+import pytest
 import pyomo.environ as pyo
 from pyomo.core.expr.visitor import polynomial_degree
 
 from gdplib.benchmark import (
     DEFAULT_GAMS_OPTCR,
     DEFAULT_STRATEGIES,
+    GDPOPT_CUSTOM_INIT_STRATEGIES,
     PR58_BENCHMARK_INSTANCES,
     _benchmark_metadata,
     _generate_summary,
@@ -96,16 +98,49 @@ def test_gdpopt_local_profile_uses_role_solvers():
     assert "$onecho > baron.opt" not in kwargs["nlp_solver_args"]["add_options"]
 
 
-def test_gdpopt_model_initialization_kwargs_use_custom_disjuncts():
+@pytest.mark.parametrize("strategy", sorted(GDPOPT_CUSTOM_INIT_STRATEGIES))
+def test_gdpopt_model_initialization_kwargs_use_custom_disjuncts(strategy):
     import gdplib.positioning
 
     model = gdplib.positioning.build_model()
 
-    kwargs = _gdpopt_model_initialization_kwargs(model)
+    kwargs = _gdpopt_model_initialization_kwargs(model, strategy)
 
     assert kwargs["init_algorithm"] == "custom_disjuncts"
     assert len(kwargs["custom_init_disjuncts"]) == 1
     assert len(kwargs["custom_init_disjuncts"][0]) == len(model.consumers)
+
+
+def test_gdpopt_custom_initialization_is_not_passed_to_unsupported_strategies():
+    import gdplib.positioning
+
+    model = gdplib.positioning.build_model()
+
+    unsupported_strategies = set(DEFAULT_STRATEGIES) - GDPOPT_CUSTOM_INIT_STRATEGIES
+    assert _gdpopt_model_initialization_kwargs(model, "gdpopt.enumerate") == {}
+    assert _gdpopt_model_initialization_kwargs(model, "gdpopt.lbb") == {}
+    for strategy in unsupported_strategies:
+        assert _gdpopt_model_initialization_kwargs(model, strategy) == {}
+
+
+def test_gdpopt_unsupported_initialization_strategies_accept_benchmark_kwargs():
+    import gdplib.positioning
+
+    model = gdplib.positioning.build_model()
+
+    for strategy in ("gdpopt.enumerate", "gdpopt.lbb"):
+        kwargs = _gdpopt_solve_kwargs(
+            30,
+            "gams",
+            "dicopt",
+            gams_nlp_solver="ipopth",
+            gams_mip_solver="gurobi",
+            gams_minlp_solver="dicopt",
+            gams_local_minlp_solver="dicopt",
+        )
+        kwargs.update(_gdpopt_model_initialization_kwargs(model, strategy))
+
+        pyo.SolverFactory(strategy).CONFIG().set_value(kwargs)
 
 
 def test_json_safe_result_replaces_non_finite_values():

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -12,6 +12,7 @@ from gdplib.benchmark import (
     _benchmark_metadata,
     _generate_summary,
     _gams_solve_options,
+    _gdpopt_model_initialization_kwargs,
     _gdpopt_solve_kwargs,
     _json_safe_result,
     _resolve_solver_profile,
@@ -93,6 +94,18 @@ def test_gdpopt_local_profile_uses_role_solvers():
     assert "option optcr=1e-6;" in kwargs["minlp_solver_args"]["add_options"]
     assert "option optcr=1e-6;" in kwargs["local_minlp_solver_args"]["add_options"]
     assert "$onecho > baron.opt" not in kwargs["nlp_solver_args"]["add_options"]
+
+
+def test_gdpopt_model_initialization_kwargs_use_custom_disjuncts():
+    import gdplib.positioning
+
+    model = gdplib.positioning.build_model()
+
+    kwargs = _gdpopt_model_initialization_kwargs(model)
+
+    assert kwargs["init_algorithm"] == "custom_disjuncts"
+    assert len(kwargs["custom_init_disjuncts"]) == 1
+    assert len(kwargs["custom_init_disjuncts"][0]) == len(model.consumers)
 
 
 def test_json_safe_result_replaces_non_finite_values():

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -104,11 +104,34 @@ def test_gdpopt_model_initialization_kwargs_use_custom_disjuncts(strategy):
 
     model = gdplib.positioning.build_model()
 
-    kwargs = _gdpopt_model_initialization_kwargs(model, strategy)
+    kwargs = _gdpopt_model_initialization_kwargs(model, strategy, custom_init=True)
 
     assert kwargs["init_algorithm"] == "custom_disjuncts"
     assert len(kwargs["custom_init_disjuncts"]) == 1
     assert len(kwargs["custom_init_disjuncts"][0]) == len(model.consumers)
+
+    # Supported strategies must accept the warm-start kwargs without a solve.
+    solve_kwargs = _gdpopt_solve_kwargs(
+        30,
+        "gams",
+        "dicopt",
+        gams_nlp_solver="ipopth",
+        gams_mip_solver="gurobi",
+        gams_minlp_solver="dicopt",
+        gams_local_minlp_solver="dicopt",
+    )
+    solve_kwargs.update(kwargs)
+    pyo.SolverFactory(strategy).CONFIG().set_value(solve_kwargs)
+
+
+def test_gdpopt_custom_initialization_is_opt_in():
+    import gdplib.positioning
+
+    model = gdplib.positioning.build_model()
+
+    # Default is cold start even when the model provides an initial set.
+    for strategy in sorted(GDPOPT_CUSTOM_INIT_STRATEGIES):
+        assert _gdpopt_model_initialization_kwargs(model, strategy) == {}
 
 
 def test_gdpopt_custom_initialization_is_not_passed_to_unsupported_strategies():
@@ -117,10 +140,14 @@ def test_gdpopt_custom_initialization_is_not_passed_to_unsupported_strategies():
     model = gdplib.positioning.build_model()
 
     unsupported_strategies = set(DEFAULT_STRATEGIES) - GDPOPT_CUSTOM_INIT_STRATEGIES
-    assert _gdpopt_model_initialization_kwargs(model, "gdpopt.enumerate") == {}
-    assert _gdpopt_model_initialization_kwargs(model, "gdpopt.lbb") == {}
+    for strategy in ("gdpopt.enumerate", "gdpopt.lbb"):
+        assert (
+            _gdpopt_model_initialization_kwargs(model, strategy, custom_init=True) == {}
+        )
     for strategy in unsupported_strategies:
-        assert _gdpopt_model_initialization_kwargs(model, strategy) == {}
+        assert (
+            _gdpopt_model_initialization_kwargs(model, strategy, custom_init=True) == {}
+        )
 
 
 def test_gdpopt_unsupported_initialization_strategies_accept_benchmark_kwargs():
@@ -138,7 +165,9 @@ def test_gdpopt_unsupported_initialization_strategies_accept_benchmark_kwargs():
             gams_minlp_solver="dicopt",
             gams_local_minlp_solver="dicopt",
         )
-        kwargs.update(_gdpopt_model_initialization_kwargs(model, strategy))
+        kwargs.update(
+            _gdpopt_model_initialization_kwargs(model, strategy, custom_init=True)
+        )
 
         pyo.SolverFactory(strategy).CONFIG().set_value(kwargs)
 

--- a/tests/test_positioning.py
+++ b/tests/test_positioning.py
@@ -1,0 +1,127 @@
+import math
+import os
+
+import pytest
+import pyomo.environ as pyo
+from pyomo.gdp import Disjunct, Disjunction
+from pyomo.opt import TerminationCondition
+
+from gdplib.benchmark import _gdpopt_model_initialization_kwargs, _gdpopt_solve_kwargs
+from gdplib.positioning import build_model
+
+
+def _consumer_best_existing_distance(model, consumer):
+    return min(
+        sum(
+            pyo.value(model.weights[consumer, location])
+            * (
+                pyo.value(model.existing_products[product, location])
+                - pyo.value(model.ideal_points[consumer, location])
+            )
+            ** 2
+            for location in model.locations
+        )
+        for product in model.products
+    )
+
+
+def _consumer_max_new_product_distance(model, consumer):
+    return sum(
+        pyo.value(model.weights[consumer, location])
+        * max(
+            (model.x[location].lb - pyo.value(model.ideal_points[consumer, location]))
+            ** 2,
+            (model.x[location].ub - pyo.value(model.ideal_points[consumer, location]))
+            ** 2,
+        )
+        for location in model.locations
+    )
+
+
+def test_positioning_slack_bounds_are_source_derived():
+    model = build_model()
+    expected_bounds = {}
+
+    for consumer in model.consumers:
+        expected_bounds[consumer] = max(
+            0,
+            _consumer_max_new_product_distance(model, consumer)
+            - _consumer_best_existing_distance(model, consumer),
+        )
+
+        assert pyo.value(model.consumer_slack_bound[consumer]) == pytest.approx(
+            expected_bounds[consumer]
+        )
+
+    assert model.U.lb == 0
+    assert model.U.ub == pytest.approx(max(expected_bounds.values()))
+    assert model.U.ub < 5000
+
+
+def test_positioning_gdpopt_initialization_set_matches_verified_solution():
+    model = build_model()
+    (initial_disjuncts,) = model.gdpopt_initial_disjuncts
+
+    selected_consumers = [
+        consumer
+        for consumer in model.consumers
+        if model.d[consumer].disjuncts[0] in initial_disjuncts
+    ]
+
+    assert selected_consumers == [1, 6, 8, 15, 17, 20, 25]
+    for consumer in model.consumers:
+        assert (
+            sum(
+                disjunct in initial_disjuncts
+                for disjunct in model.d[consumer].disjuncts
+            )
+            == 1
+        )
+
+
+@pytest.mark.parametrize("transformation", ["gdp.bigm", "gdp.hull"])
+def test_positioning_reformulates_with_supported_gdp_transformations(transformation):
+    model = build_model()
+
+    pyo.TransformationFactory(transformation).apply_to(model)
+
+    assert not any(model.component_data_objects(pyo.LogicalConstraint, active=True))
+    assert not any(model.component_data_objects(Disjunction, active=True))
+    assert not any(model.component_data_objects(Disjunct, active=True))
+
+
+@pytest.mark.skipif(
+    os.environ.get("GDPLIB_RUN_GAMS_TESTS") != "1",
+    reason="set GDPLIB_RUN_GAMS_TESTS=1 to run optional GAMS-backed tests",
+)
+def test_positioning_gloa_runs_with_gams_local_profile():
+    if not pyo.SolverFactory("gams").available(False):
+        pytest.skip("GAMS solver interface is not available")
+
+    model = build_model()
+    kwargs = _gdpopt_solve_kwargs(
+        60,
+        "gams",
+        "dicopt",
+        gams_nlp_solver="ipopth",
+        gams_mip_solver="gurobi",
+        gams_minlp_solver="dicopt",
+        gams_local_minlp_solver="dicopt",
+    )
+    kwargs["tee"] = False
+    kwargs.update(_gdpopt_model_initialization_kwargs(model))
+    for key in (
+        "nlp_solver_args",
+        "mip_solver_args",
+        "minlp_solver_args",
+        "local_minlp_solver_args",
+    ):
+        kwargs[key]["tee"] = False
+
+    results = pyo.SolverFactory("gdpopt.gloa").solve(model, **kwargs)
+
+    assert results.solver.termination_condition == TerminationCondition.optimal
+    assert math.isfinite(results.problem.lower_bound)
+    assert math.isfinite(results.problem.upper_bound)
+    assert results.problem.lower_bound == pytest.approx(-8.06413617, abs=1e-6)
+    assert results.problem.upper_bound == pytest.approx(-8.06413617, abs=1e-6)

--- a/tests/test_positioning.py
+++ b/tests/test_positioning.py
@@ -109,7 +109,7 @@ def test_positioning_gloa_runs_with_gams_local_profile():
         gams_local_minlp_solver="dicopt",
     )
     kwargs["tee"] = False
-    kwargs.update(_gdpopt_model_initialization_kwargs(model))
+    kwargs.update(_gdpopt_model_initialization_kwargs(model, "gdpopt.gloa"))
     for key in (
         "nlp_solver_args",
         "mip_solver_args",


### PR DESCRIPTION
## Summary

- Adds a generic benchmark hook for model-provided GDPOpt custom-disjunct initialization.
- Provides the BARON-verified active disjunct set for `positioning`, so `gdpopt.gloa` initializes from the benchmark solution without changing the model feasible region.
- Tightens `positioning.U` from the source location bounds and adds focused positioning tests.

## Tests run

- `pixi run pytest tests/test_positioning.py tests/test_benchmark.py::test_gdpopt_model_initialization_kwargs_use_custom_disjuncts -v --tb=short` - passed, 5 passed, 1 skipped.
- `pixi run gdplib-benchmark run --instances positioning --strategies gdpopt.gloa --timelimit 60 --run-id issue73_positioning_gloa_custom_init_60s` - passed, 0 failures; GLOA optimal, objective `-8.0641361676497`, lower bound `-8.0641361676497`, upper bound `-8.0641361676497`, 1 iteration, 1.47 s.
- Direct Big-M/BARON cross-check via Pixi Python script - passed; GAMS/BARON optimal, objective `-8.0641361647335`, `U = 0`, selected consumers `[1, 6, 8, 15, 17, 20, 25]`.
- `pixi run python generate_model_size_report.py` - passed; no tracked report changes.
- `pixi run pytest tests/test_positioning.py tests/test_benchmark.py -v --tb=short` - passed, 26 passed, 1 skipped.
- `pixi run pytest tests/test_module_imports.py -v --tb=short` - passed, 74 passed.
- `env GDPLIB_RUN_GAMS_TESTS=1 pixi run pytest tests/test_positioning.py::test_positioning_gloa_runs_with_gams_local_profile -v --tb=short` - passed, 1 passed.
- `pixi run test` - passed, 340 passed, 2 skipped.
- `pixi run lint` - passed; Black clean, critical flake8 reported `0`, style inventory completed with `--exit-zero`, typos completed.
- `git diff --check` - passed.

## Notes

- Generated benchmark artifacts were inspected locally but not committed.
- Issue #104 was considered; this PR does not change release, packaging, Pixi platform support, or lock-file policy.

Closes #73
