### PR TITLE
Record verified solution values for five models

### DIFF
--- a/gdplib/cstr/README.md
+++ b/gdplib/cstr/README.md
@@ -14,7 +14,12 @@ The optimal solution should yield NT reactors with a recycle before reactor NT.
 
 ### Optimal Solution
 
-Best known objective value: 3.0620145766 (optimal)
+Best known objective value: 3.062003537511728 (proven optimal)
+
+Verified with GAMS/BARON on the `gdp.bigm` reformulation at `optcr=optca=0`
+(lower bound equal to upper bound), 2026-08-18. The solution point passes all
+six GAMS/Examiner checks (primal and dual bounds and constraints at 1e-6,
+complementary slackness at 1e-7) with the discrete variables fixed. See #152.
 
 ### Size
 

--- a/gdplib/ex1_linan_2023/README.md
+++ b/gdplib/ex1_linan_2023/README.md
@@ -10,6 +10,15 @@ The objective function originates from Problem No. 6 of Gomez's paper, and Li√±√
 
 ## Problem details
 
+### Solution
+
+Best known objective value: -0.9996.
+
+Best found with GAMS/BARON on the `gdp.bigm` reformulation (120 s,
+`optcr=1e-6`), 2026-08-18; not proven optimal. The solution point passes all
+six GAMS/Examiner checks (primal and dual bounds and constraints at 1e-6,
+complementary slackness at 1e-7) with the discrete variables fixed. See #152.
+
 ### Size
 
 | Component             |   Number |

--- a/gdplib/grid/README.md
+++ b/gdplib/grid/README.md
@@ -28,6 +28,14 @@ The objective is to minimize total generator and line capacity slack subject to 
 event constraint at alpha=0.9. Optimal objective values for various ATLEAST
 configurations are reported in the reference above.
 
+Best known objective value for the default instance: 0.0 (proven optimal;
+zero slack is attainable, so no capacity expansion is required).
+
+Verified with GAMS/BARON on the `gdp.bigm` reformulation at `optcr=optca=0`
+(lower bound equal to upper bound), 2026-08-18. The solution point passes all
+six GAMS/Examiner checks (primal and dual bounds and constraints at 1e-6,
+complementary slackness at 1e-7) with the discrete variables fixed. See #152.
+
 ### Size
 
 Problem size for the default instance with `active_gens=4`, `active_lines=20`, and

--- a/gdplib/multiperiod_blending/README.md
+++ b/gdplib/multiperiod_blending/README.md
@@ -6,3 +6,17 @@ If you decide to use these instances or model, please cite the following papers:
 > Ovalle, D., Bhatia, A., Laird, C. D., & Grossmann, I. E. (2026). A logic-based decomposition for the global optimization of the multiperiod blending problem using symmetry-breaking cuts. Industrial & Engineering Chemistry Research, 65(7), 3981–3998. https://doi.org/10.1021/acs.iecr.5c02853
 > 
 > Lotero, I., Trespalacios, F., Grossmann, I. E., Papageorgiou, D. J., & Cheon, M.-S. (2016). An MILP-MINLP decomposition method for the global optimization of a source based model of the multiperiod blending problem. Computers & Chemical Engineering, 87, 13–35. https://doi.org/10.1016/j.compchemeng.2015.12.017 
+
+## Problem Details
+
+### Solution
+
+Best known objective value for the default instance: 337.155000916326 (maximization).
+
+Best found with GAMS/BARON on the `gdp.bigm` reformulation (120 s,
+`optcr=1e-6`), 2026-08-18; not proven optimal. The solution point passes all
+six GAMS/Examiner checks (primal and dual bounds and constraints at 1e-6,
+complementary slackness at 1e-7) with the discrete variables fixed. See #152.
+
+Note that this package ships 60 instances under `instances_json/`; the value
+above is for the instance built by the default `build_model()`.

--- a/gdplib/pandemic/README.md
+++ b/gdplib/pandemic/README.md
@@ -30,6 +30,13 @@ The objective is to minimize total quarantine intervention subject to the event
 constraint at alpha = 0.9. Optimal objective values for various alpha levels are
 reported in the reference above.
 
+Best known objective value for the default instance: 21.208560364904056.
+
+Best found with GAMS/BARON on the `gdp.bigm` reformulation (120 s,
+`optcr=1e-6`), 2026-08-18; not proven optimal. The solution point passes all
+six GAMS/Examiner checks (primal and dual bounds and constraints at 1e-6,
+complementary slackness at 1e-7) with the discrete variables fixed. See #152.
+
 ### Size
 
 Problem size for the default instance with `num_times=101`:


### PR DESCRIPTION
Follows the solution-verification sweep in #152. No model code changes; READMEs only.

## What changed

- **`cstr`**: the recorded value was stale. The README carried 3.0620145766; GAMS/BARON at `optcr=optca=0` proves **3.062003537511728** with lower bound equal to upper bound. Updated, and labelled *proven optimal*.
- **`ex1_linan_2023`, `grid`, `multiperiod_blending`, `pandemic`**: these recorded no solution value at all. Each now carries the best value found under a stated budget (GAMS/BARON on `gdp.bigm`, 120 s, `optcr=1e-6`), explicitly labelled *not proven optimal*.

Every recorded point is backed by a GAMS/Examiner audit: primal and dual variable bounds and constraints at 1e-6, and both complementary-slackness conditions at 1e-7, with the discrete variables fixed. Each entry states its solver, tolerance, date, and audit status, so a later reader can tell a proven value from a best-found one and re-check either.

Two notes for reviewers:

- `grid`'s optimum is 0.0, which is meaningful rather than degenerate: the objective minimizes total capacity slack, and zero slack turns out to be attainable for the default instance, so no expansion is required.
- `multiperiod_blending` ships 60 instances under `instances_json/`; the recorded value is for the instance built by the default `build_model()`, and the README now says so.

Models with PRs in flight are deliberately untouched here; their values should be recorded as those PRs land. `water_network` and `reverse_electrodialysis` are also untouched, since their recorded values need the discussions on #151 and #149 respectively (scaling, and a units/value discrepancy) before they can be stated cleanly.

## Verification

`pixi run pytest tests/` — 335 passed, 1 skipped.

Refs #152, #105